### PR TITLE
feat : 박람회 페이지 권한 분기처리

### DIFF
--- a/src/api/service/expo-admin/authService.jsx
+++ b/src/api/service/expo-admin/authService.jsx
@@ -1,0 +1,11 @@
+import instance from "../../lib/axios";
+
+export const getMyExpos = async () => {
+  try {
+    const response = await instance.get("/expos/my");
+    return response.data;
+  } catch (error) {
+    const message = error.response?.data?.message || "현재 관리 중인 박람회 조회 중 오류 발생";
+    throw new Error(message);
+  }
+};

--- a/src/expo-admin/components/operatorSection/OperatorSection.module.css
+++ b/src/expo-admin/components/operatorSection/OperatorSection.module.css
@@ -47,6 +47,10 @@
   outline: none;
 }
 
+.inputField:focus {
+  border-color: #1e2a38;
+}
+
 .icon {
   position: absolute;
   right: 0;

--- a/src/expo-admin/layout/ExpoAdminLayout.jsx
+++ b/src/expo-admin/layout/ExpoAdminLayout.jsx
@@ -1,18 +1,41 @@
-import { Outlet } from "react-router-dom";
-import styles from './ExpoAdminLayout.module.css'
+import { useEffect, useState } from "react";
+import { Outlet, useParams } from "react-router-dom";
+import styles from './ExpoAdminLayout.module.css';
 import ExpoAdminHeader from "./header/ExpoAdminHeader";
 import ExpoAdminSideBar from "./sidebar/ExpoAdminSidebar";
+import { getMyExpos } from "../../api/service/expo-admin/authService";
 
 function ExpoAdminLayout() {
+  const [hasPermission, setHasPermission] = useState(null);
+  const { expoId } = useParams();
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      try {
+        const expos = await getMyExpos(); //현재 로그인 한 사용자 기반으로 활성화된 exopId 반환
+        const expoIdNumber = Number(expoId);
+        setHasPermission(expos.includes(expoIdNumber));
+      } catch (error) {
+        console.error("권한 확인 실패:", error.message);
+        setHasPermission(false);
+      }
+    };
+    checkPermission();
+  }, [expoId]);
+
+  if (hasPermission === null) return null;
+
+  if (!hasPermission) return <NoAccessPage />; //권한 없음 페이지 렌더링
+
   return (
     <div className={styles.layout}>
       <div className={styles.contentWrapper}>
         <div className={styles.sidebar}>
-          <ExpoAdminSideBar></ExpoAdminSideBar>
+          <ExpoAdminSideBar />
         </div>
         <div className={styles.main}>
           <div className={styles.header}>
-            <ExpoAdminHeader></ExpoAdminHeader>
+            <ExpoAdminHeader />
           </div>
           <div className={styles.content}>
             <Outlet />
@@ -24,3 +47,24 @@ function ExpoAdminLayout() {
 }
 
 export default ExpoAdminLayout;
+
+function NoAccessPage() {
+  return (
+    <div style={{
+      minHeight: "60vh",
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "center",
+      alignItems: "center",
+      textAlign: "center",
+      padding: "2rem"
+    }}>
+      <h2 style={{ fontSize: "1.75rem", color: "#d32f2f", marginBottom: "1rem" }}>
+        [403 Forbidden] 접근 권한이 없습니다
+      </h2>
+      <p style={{ fontSize: "1rem", color: "#555" }}>
+        이 박람회에 대한 관리 권한이 없습니다.
+      </p>
+    </div>
+  );
+}

--- a/src/expo-admin/layout/header/ExpoAdminHeader.jsx
+++ b/src/expo-admin/layout/header/ExpoAdminHeader.jsx
@@ -2,29 +2,37 @@ import { useLocation } from "react-router-dom";
 import styles from './ExpoAdminHeader.module.css';
 
 const pathMap = {
-  '/expo/admin': ['대시보드'],
-  '/expo/admin/setting': ['박람회 관리', '박람회 상세'],
-  '/expo/admin/booths': ['박람회 관리', '참가 부스'],
-  '/expo/admin/events': ['박람회 관리', '행사 일정'],
-  '/expo/admin/payments': ['예약 관리', '결제 내역'],
-  '/expo/admin/reservations': ['예약 관리', '예약자 리스트'],
-  '/expo/admin/emails': ['예약 관리', '이메일 전송 이력'],
-  '/expo/admin/entry': ['입장 관리'],
-  '/expo/admin/operation': ['운영 설정'],
-  '/expo/admin/settlement': ['정산'],
-  '/expo/admin/inquiry': ['문의'],
+  '/expos/:expoId/admin': ['대시보드'],
+  '/expos/:expoId/admin/setting': ['박람회 관리', '박람회 상세'],
+  '/expos/:expoId/admin/booths': ['박람회 관리', '참가 부스'],
+  '/expos/:expoId/admin/events': ['박람회 관리', '행사 일정'],
+  '/expos/:expoId/admin/payments': ['예약 관리', '결제 내역'],
+  '/expos/:expoId/admin/reservations': ['예약 관리', '예약자 리스트'],
+  '/expos/:expoId/admin/emails': ['예약 관리', '이메일 전송 이력'],
+  '/expos/:expoId/admin/operation': ['운영 설정'],
+  '/expos/:expoId/admin/settlement': ['정산'],
+  '/expos/:expoId/admin/inquiry': ['문의'],
 };
+
+// 경로 내 :expoId를 무시하고 매칭하기 위한 헬퍼 함수
+function normalizePath(pathname) {
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments.length >= 3 && segments[0] === 'expos' && segments[2] === 'admin') {
+    segments[1] = ':expoId'; // expoId 자리에 변수로 대체
+  }
+  return '/' + segments.join('/');
+}
 
 function ExpoAdminHeader() {
   const location = useLocation();
-  const currentPath = location.pathname;
+  const currentPath = normalizePath(location.pathname); // 경로 정규화
 
   const matchedKey = Object.keys(pathMap)
     .sort((a, b) => b.length - a.length)
     .find((key) => currentPath.startsWith(key));
 
   const crumbs = matchedKey ? pathMap[matchedKey] : [];
-  const isDashboard = matchedKey === '/expo/admin';
+  const isDashboard = matchedKey === '/expos/:expoId/admin';
 
   return (
     <nav className={styles.breadcrumb}>

--- a/src/expo-admin/layout/sidebar/ExpoAdminSidebar.jsx
+++ b/src/expo-admin/layout/sidebar/ExpoAdminSidebar.jsx
@@ -6,7 +6,7 @@ import {
   sidebarClasses,
   menuClasses,
 } from 'react-pro-sidebar';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { AiOutlineBarChart } from 'react-icons/ai';
 import { MdEventNote } from 'react-icons/md';
@@ -18,13 +18,16 @@ import ExpoAdminInfoBox from '../../components/InfoBox/ExpoAdminInfoBox';
 
 function ExpoAdminSideBar() {
   const location = useLocation();
+  const { expoId } = useParams(); // ✅ 현재 expoId 추출
   const currentPath = location.pathname;
 
   const [selectedMenu, setSelectedMenu] = useState('');
   const [openSubMenus, setOpenSubMenus] = useState([]);
 
-  const expoPaths = ['/expo/admin/setting', '/expo/admin/booths', '/expo/admin/events'];
-  const reservationPaths = ['/expo/admin/payments', '/expo/admin/reservations', '/expo/admin/emails'];
+  const basePath = `/expos/${expoId}/admin`;
+
+  const expoPaths = [`${basePath}/setting`, `${basePath}/booths`, `${basePath}/events`];
+  const reservationPaths = [`${basePath}/payments`, `${basePath}/reservations`, `${basePath}/emails`];
 
   useEffect(() => {
     setSelectedMenu(currentPath);
@@ -35,7 +38,7 @@ function ExpoAdminSideBar() {
     } else {
       setOpenSubMenus([]);
     }
-  }, [currentPath]);
+  }, [currentPath, basePath]);
 
   const toggleSubMenu = (menuKey) => {
     setOpenSubMenus((prev) =>
@@ -89,8 +92,8 @@ function ExpoAdminSideBar() {
 
         <MenuItem
           icon={<AiOutlineBarChart />}
-          component={<Link to="/expo/admin" />}
-          active={selectedMenu === '/expo/admin'}
+          component={<Link to={`${basePath}`} />}
+          active={selectedMenu === `${basePath}`}
         >
           대시 보드
         </MenuItem>
@@ -106,20 +109,20 @@ function ExpoAdminSideBar() {
           onOpenChange={() => toggleSubMenu('expo')}
         >
           <MenuItem
-            component={<Link to="/expo/admin/setting" />}
-            active={selectedMenu === '/expo/admin/setting'}
+            component={<Link to={`${basePath}/setting`} />}
+            active={selectedMenu === `${basePath}/setting`}
           >
             박람회 상세
           </MenuItem>
           <MenuItem
-            component={<Link to="/expo/admin/booths" />}
-            active={selectedMenu === '/expo/admin/booths'}
+            component={<Link to={`${basePath}/booths`} />}
+            active={selectedMenu === `${basePath}/booths`}
           >
             참가 부스
           </MenuItem>
           <MenuItem
-            component={<Link to="/expo/admin/events" />}
-            active={selectedMenu === '/expo/admin/events'}
+            component={<Link to={`${basePath}/events`} />}
+            active={selectedMenu === `${basePath}/events`}
           >
             행사 일정
           </MenuItem>
@@ -132,20 +135,20 @@ function ExpoAdminSideBar() {
           onOpenChange={() => toggleSubMenu('reservation')}
         >
           <MenuItem
-            component={<Link to="/expo/admin/payments" />}
-            active={selectedMenu === '/expo/admin/payments'}
+            component={<Link to={`${basePath}/payments`} />}
+            active={selectedMenu === `${basePath}/payments`}
           >
             결제 내역
           </MenuItem>
           <MenuItem
-            component={<Link to="/expo/admin/reservations" />}
-            active={selectedMenu === '/expo/admin/reservations'}
+            component={<Link to={`${basePath}/reservations`} />}
+            active={selectedMenu === `${basePath}/reservations`}
           >
             예약자 리스트
           </MenuItem>
           <MenuItem
-            component={<Link to="/expo/admin/emails" />}
-            active={selectedMenu === '/expo/admin/emails'}
+            component={<Link to={`${basePath}/emails`} />}
+            active={selectedMenu === `${basePath}/emails`}
           >
             이메일 전송 이력
           </MenuItem>
@@ -153,24 +156,24 @@ function ExpoAdminSideBar() {
 
         <MenuItem
           icon={<FiSettings />}
-          component={<Link to="/expo/admin/operation" />}
-          active={selectedMenu === '/expo/admin/operation'}
+          component={<Link to={`${basePath}/operation`} />}
+          active={selectedMenu === `${basePath}/operation`}
         >
           운영 설정
         </MenuItem>
 
         <MenuItem
           icon={<BiMoneyWithdraw />}
-          component={<Link to="/expo/admin/settlement" />}
-          active={selectedMenu === '/expo/admin/settlement'}
+          component={<Link to={`${basePath}/settlement`} />}
+          active={selectedMenu === `${basePath}/settlement`}
         >
           정산
         </MenuItem>
 
         <MenuItem
           icon={<FiMessageSquare />}
-          component={<Link to="/expo/admin/inquiry" />}
-          active={selectedMenu === '/expo/admin/inquiry'}
+          component={<Link to={`${basePath}/inquiry`} />}
+          active={selectedMenu === `${basePath}/inquiry`}
         >
           문의
         </MenuItem>

--- a/src/routes/ExpoAdminRoutes.jsx
+++ b/src/routes/ExpoAdminRoutes.jsx
@@ -14,7 +14,7 @@ import Inquiry from '../expo-admin/pages/inquiry/Inquiry';
 function ExpoAdminRoutes() {
   return (
       <Routes>
-        <Route path="/expo/admin" element={<ExpoAdminLayout />}>
+        <Route path="/expos/:expoId/admin" element={<ExpoAdminLayout />}>
           <Route index element={<Dashboard />} />
           <Route path="setting" element={<Settings />} />
           <Route path="booths" element={<Booths/>}/>


### PR DESCRIPTION
로그인한 사용자 기반으로 운영중인 박람회 리스트를 받아와 박람회 페이지 권한 분기처리를 구현하였습니다.
/expos/:expoId/admin 으로 접근 가능하며 권한이 없을때는 권함없음 페이지로 이동됩니다.