### PR TITLE
feat: 부스 등록 api 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ dist-ssr
 
 .env
 .env.*
+
+# Gemini files
+.gemini
+prompt.txt
+GEMINI.md
+.prMessage

--- a/src/api/service/expo-admin/boothService.jsx
+++ b/src/api/service/expo-admin/boothService.jsx
@@ -1,0 +1,44 @@
+import instance from "../../lib/axios";
+
+// 부스 목록 조회
+export const getBooths = async (expoId) => {
+  try {
+    const response = await instance.get(`/expos/${expoId}/booths`);
+    return response.data;
+  } catch (error) {
+    const message = error.response?.data?.message || "부스 목록 조회 중 오류 발생";
+    throw new Error(message);
+  }
+};
+
+// 부스 등록
+export const registerBooth = async (expoId, data) => {
+  try {
+    const response = await instance.post(`/expos/${expoId}/booths`, data);
+    return response.data;
+  } catch (error) {
+    const message = error.response?.data?.message || "부스 등록 중 오류 발생";
+    throw new Error(message);
+  }
+};
+
+// 부스 수정
+export const updateBooth = async (expoId, boothId, data) => {
+  try {
+    const response = await instance.put(`/expos/${expoId}/booths/${boothId}`, data);
+    return response.data;
+  } catch (error) {
+    const message = error.response?.data?.message || "부스 수정 중 오류 발생";
+    throw new Error(message);
+  }
+};
+
+// 부스 삭제
+export const deleteBooth = async (expoId, boothId) => {
+  try {
+    await instance.delete(`/expos/${expoId}/booths/${boothId}`);
+  } catch (error) {
+    const message = error.response?.data?.message || "부스 삭제 중 오류 발생";
+    throw new Error(message);
+  }
+};

--- a/src/expo-admin/components/boothSettingForm/BoothSettingForm.jsx
+++ b/src/expo-admin/components/boothSettingForm/BoothSettingForm.jsx
@@ -1,26 +1,29 @@
-import { useState} from 'react';
+import { useState } from 'react';
 import styles from './BoothSettingForm.module.css';
 import ToggleSwitch from '../../../common/components/toggleSwitch/ToggleSwitch';
 import { FaCheckCircle, FaTimesCircle } from 'react-icons/fa';
 import ToastSuccess from '../../../common/components/toastSuccess/ToastSuccess';
+import ToastFail from '../../../common/components/toastFail/ToastFail';
+import { registerBooth } from '../../../api/service/expo-admin/boothService';
+import { useParams } from 'react-router-dom';
 
 function BoothSettingForm({ onSubmit }) {
+  const { expoId } = useParams();
   const [form, setForm] = useState(initForm());
-  const [isPremium, setIsPremium] = useState(false);
-  const [showToast, setShowToast] = useState(false);
+  const [showSuccessToast, setShowSuccessToast] = useState(false);
+  const [failToast, setFailToast] = useState({ show: false, message: '' });
 
   function initForm() {
     return {
-      boothLocation: '',
-      priority: '',
-      companyName: '',
+      boothNumber: '',
+      name: '',
       description: '',
-      ceo: '',
-      address: '',
-      website: '',
-      phone: '',
-      email: '',
-      imageUrl: '',
+      mainImageUrl: '',
+      contactName: '',
+      contactPhone: '',
+      contactEmail: '',
+      isPremium: false,
+      displayRank: '',
     };
   }
 
@@ -29,32 +32,136 @@ function BoothSettingForm({ onSubmit }) {
     setForm((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleSubmit = () => {
-    if (!form.companyName || !form.boothLocation) {
-      alert('회사명과 부스 위치는 필수입니다.');
+  const handleToggle = (e) => {
+    const { checked } = e.target;
+    setForm((prev) => ({
+      ...prev,
+      isPremium: checked,
+      displayRank: checked ? prev.displayRank : '',
+    }));
+  };
+
+  const showFailToast = (message) => {
+    setFailToast({ show: true, message });
+    setTimeout(() => {
+      setFailToast({ show: false, message: '' });
+    }, 4000);
+  };
+
+  const validateForm = () => {
+    const {
+      boothNumber,
+      name,
+      description,
+      mainImageUrl,
+      contactName,
+      contactPhone,
+      contactEmail,
+    } = form;
+
+    if (!boothNumber) {
+      showFailToast('부스 번호는 필수입니다.');
+      return false;
+    }
+    if (boothNumber.length > 30) {
+      showFailToast('부스 번호는 30자 이하여야 합니다.');
+      return false;
+    }
+    if (!name) {
+      showFailToast('부스 이름은 필수입니다.');
+      return false;
+    }
+    if (name.length > 100) {
+      showFailToast('부스 이름은 100자 이하여야 합니다.');
+      return false;
+    }
+    if (!description) {
+      showFailToast('부스 설명은 필수입니다.');
+      return false;
+    }
+    if (!mainImageUrl) {
+      showFailToast('메인 이미지 URL은 필수입니다.');
+      return false;
+    }
+    if (mainImageUrl.length > 500) {
+      showFailToast('메인 이미지 URL은 500자 이하여야 합니다.');
+      return false;
+    }
+    if (!contactName) {
+      showFailToast('담당자 이름은 필수입니다.');
+      return false;
+    }
+    if (contactName.length > 30) {
+      showFailToast('담당자 이름은 30자 이하여야 합니다.');
+      return false;
+    }
+    if (!contactPhone) {
+      showFailToast('담당자 연락처는 필수입니다.');
+      return false;
+    }
+    const phoneRegex = /^\d{2,3}-\d{3,4}-\d{4}$/;
+    if (!phoneRegex.test(contactPhone)) {
+      showFailToast('유효한 전화번호 형식이 아닙니다. (예: 010-1234-5678)');
+      return false;
+    }
+    if (contactPhone.length > 13) {
+      showFailToast('담당자 연락처는 13자 이하여야 합니다.');
+      return false;
+    }
+    if (!contactEmail) {
+      showFailToast('담당자 이메일은 필수입니다.');
+      return false;
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(contactEmail)) {
+      showFailToast('유효한 이메일 형식이 아닙니다.');
+      return false;
+    }
+    if (contactEmail.length > 100) {
+      showFailToast('담당자 이메일은 100자 이하여야 합니다.');
+      return false;
+    }
+    return true;
+  };
+
+  const handleSubmit = async () => {
+    if (!validateForm()) {
       return;
     }
 
     const payload = {
       ...form,
-      priority: isPremium ? parseInt(form.priority || '0', 10) : null,
-      isPremium,
+      displayRank: form.isPremium ? parseInt(form.displayRank || '0', 10) : null,
     };
 
-    onSubmit(payload);
-    setForm(initForm());
-    setIsPremium(false);
-    setShowToast(true);
-    setTimeout(() => setShowToast(false), 2000);
+    try {
+      const result = await registerBooth(expoId, payload);
+      
+      // API 응답이 성공적인지 확인 (서버가 200 OK와 함께 에러를 보내는 경우 방지)
+      if (result) {
+        if (onSubmit) {
+          onSubmit(payload);
+        }
+        setForm(initForm()); // 실제 성공 시에만 폼 초기화
+        setShowSuccessToast(true);
+        setTimeout(() => setShowSuccessToast(false), 2000);
+      } else {
+        // API가 에러를 throw하지 않았지만, 응답 내용이 성공이 아닐 경우
+        showFailToast('등록에 실패했습니다. 서버 응답을 확인해주세요.');
+      }
+    } catch (error) {
+      showFailToast(error.message || '등록 중 오류가 발생했습니다.');
+    }
   };
 
   return (
     <div className={styles.container}>
-      {showToast && <ToastSuccess/>}
+      {showSuccessToast && <ToastSuccess />}
+      {failToast.show && <ToastFail message={failToast.message} />}
 
       <div className={styles.posterWrapper}>
         <img
-          src={form.imageUrl || 'https://designcompass.org/wp-content/uploads/2024/10/logo-naver-1536x1152.png'}
+          src={form.mainImageUrl || 'https://designcompass.org/wp-content/uploads/2024/10/logo-naver-1536x1152.png'}
           alt="부스 이미지"
           className={styles.posterImage}
         />
@@ -63,109 +170,81 @@ function BoothSettingForm({ onSubmit }) {
       <div className={styles.formGrid}>
         <div className={styles.leftColumn}>
           <div className={styles.formGroup}>
-            <label className={styles.label}>부스 위치</label>
+            <label className={styles.label}>부스 번호</label>
             <input
-              name="boothLocation"
+              name="boothNumber"
               className={styles.inputField}
-              placeholder="부스 위치 입력"
-              value={form.boothLocation}
+              placeholder="부스 번호 입력"
+              value={form.boothNumber}
               onChange={handleChange}
             />
           </div>
 
           <div className={styles.formGroup}>
-            <label className={styles.label}>프리미엄 상위 노출 신청 여부</label>
+            <label className={styles.label}>프리미엄 부스 여부</label>
             <div className={styles.toggleWrapper}>
               <ToggleSwitch
-                checked={isPremium}
-                onChange={(e) => {
-                  const checked = e.target.checked;
-                  setIsPremium(checked);
-                  if (!checked) {
-                    setForm((prev) => ({ ...prev, priority: '' }));
-                  }
-                }}
+                checked={form.isPremium}
+                onChange={handleToggle}
               />
             </div>
           </div>
 
           <div className={styles.formGroup}>
-            <label className={styles.label}>부스 순위</label>
+            <label className={styles.label}>노출 순위</label>
             <input
-              name="priority"
+              name="displayRank"
               className={styles.inputField}
               type="number"
               placeholder="숫자로 입력"
-              value={form.priority}
+              value={form.displayRank}
               onChange={handleChange}
-              disabled={!isPremium}
+              disabled={!form.isPremium}
             />
           </div>
         </div>
 
         <div className={styles.rightColumn}>
           <div className={styles.formGroup}>
-            <label className={styles.label}>회사명</label>
+            <label className={styles.label}>부스명</label>
             <input
-              name="companyName"
+              name="name"
               className={styles.inputField}
-              placeholder="회사명 입력"
-              value={form.companyName}
+              placeholder="부스명 입력"
+              value={form.name}
               onChange={handleChange}
             />
           </div>
 
           <div className={styles.formGroup}>
-            <label className={styles.label}>회사소개</label>
+            <label className={styles.label}>부스 소개</label>
             <input
               name="description"
               className={styles.inputField}
-              placeholder="회사 소개 입력"
+              placeholder="부스 소개 입력"
               value={form.description}
               onChange={handleChange}
             />
           </div>
 
           <div className={styles.formGroup}>
-            <label className={styles.label}>대표명</label>
+            <label className={styles.label}>담당자명</label>
             <input
-              name="ceo"
+              name="contactName"
               className={styles.inputField}
-              placeholder="대표명 입력"
-              value={form.ceo}
+              placeholder="담당자명 입력"
+              value={form.contactName}
               onChange={handleChange}
             />
           </div>
 
           <div className={styles.formGroup}>
-            <label className={styles.label}>주소</label>
+            <label className={styles.label}>담당자 연락처</label>
             <input
-              name="address"
+              name="contactPhone"
               className={styles.inputField}
-              placeholder="주소 입력"
-              value={form.address}
-              onChange={handleChange}
-            />
-          </div>
-
-          <div className={styles.formGroup}>
-            <label className={styles.label}>웹사이트</label>
-            <input
-              name="website"
-              className={styles.inputField}
-              placeholder="웹사이트 입력"
-              value={form.website}
-              onChange={handleChange}
-            />
-          </div>
-
-          <div className={styles.formGroup}>
-            <label className={styles.label}>담당자 전화번호</label>
-            <input
-              name="phone"
-              className={styles.inputField}
-              placeholder="전화번호 입력"
-              value={form.phone}
+              placeholder="010-1234-5678"
+              value={form.contactPhone}
               onChange={handleChange}
             />
           </div>
@@ -173,21 +252,21 @@ function BoothSettingForm({ onSubmit }) {
           <div className={styles.formGroup}>
             <label className={styles.label}>담당자 이메일</label>
             <input
-              name="email"
+              name="contactEmail"
               className={styles.inputField}
               placeholder="이메일 입력"
-              value={form.email}
+              value={form.contactEmail}
               onChange={handleChange}
             />
           </div>
 
           <div className={styles.formGroup}>
-            <label className={styles.label}>이미지 URL</label>
+            <label className={styles.label}>메인 이미지 URL</label>
             <input
-              name="imageUrl"
+              name="mainImageUrl"
               className={styles.inputField}
               placeholder="이미지 주소 입력"
-              value={form.imageUrl}
+              value={form.mainImageUrl}
               onChange={handleChange}
             />
           </div>
@@ -198,10 +277,7 @@ function BoothSettingForm({ onSubmit }) {
         <button className={`${styles.actionBtn} ${styles.submitBtn}`} onClick={handleSubmit}>
           <FaCheckCircle className={styles.iconBtn} /> 등록
         </button>
-        <button className={`${styles.actionBtn} ${styles.cancelBtn}`} onClick={() => {
-          setForm(initForm());
-          setIsPremium(false);
-        }}>
+        <button className={`${styles.actionBtn} ${styles.cancelBtn}`} onClick={() => setForm(initForm())}>
           <FaTimesCircle className={styles.iconBtn} /> 취소
         </button>
       </div>

--- a/src/expo-admin/pages/booths/Booths.jsx
+++ b/src/expo-admin/pages/booths/Booths.jsx
@@ -82,8 +82,8 @@ function Booths() {
 
   const filtered = boothList
     .filter((b) =>
-      b.companyName.includes(searchText) ||
-      b.description.includes(searchText)
+      (b.companyName && b.companyName.includes(searchText)) ||
+      (b.description && b.description.includes(searchText))
     )
     .sort((a, b) =>
       sortOrder === 'asc' ? a.priority - b.priority : b.priority - a.priority


### PR DESCRIPTION
## Expo-Admin 부스 관리 기능 추가 및 버그 수정

### 주요 변경 사항

- **부스 등록 폼 구현 (`BoothSettingForm.jsx`)**:
    - 백엔드 `BoothRegistrationRequest` DTO 명세에 맞춰 폼의 상태와 입력 필드를 개편했습니다.
    - `react-router-dom`의 `useParams`를 사용하여 현재 `expoId`를 동적으로 가져오도록 구현했습니다.

- **부스 API 서비스 추가 (`boothService.jsx`)**:
    - 부스의 CRUD(생성, 조회, 수정, 삭제)를 위한 API 요청 함수를 포함하는 `src/api/service/expo-admin/boothService.jsx` 파일을 신규 생성했습니다.
    - `axios` 인스턴스를 사용하여 API endpoint (`/expos/{expoId}/booths`)와 통신하도록 구현했습니다.

- **폼-API 연동 및 유효성 검사**:
    - '등록' 버튼 클릭 시 `registerBooth` API를 호출하여 백엔드로 데이터를 전송하도록 연동했습니다.
    - DTO 제약 조건에 기반하여 클라이언트 사이드 유효성 검사 로직을 추가했습니다.
    - 유효성 검사 실패 시 `ToastFail` 컴포넌트를 통해 사용자에게 오류 메시지를 표시하고, 성공 시 `ToastSuccess`를 표시하도록 예외 처리를 구현했습니다.

### 버그 수정

- **등록 실패 시 입력 데이터 유지**:
    - `BoothSettingForm.jsx`의 `handleSubmit` 함수에서 API 요청 실패 시에도 폼 데이터가 초기화되던 문제를 해결했습니다.
    - API 응답을 명시적으로 확인하여, 실제 성공 응답을 받았을 경우에만 폼이 초기화되도록 로직을 수정하여 사용자 경험을 개선했습니다.


- **부스 검색 필터링 오류 수정 (`Booths.jsx`)**:
    - 부스 목록 검색 시 `description` 또는 `companyName` 필드가 없는 데이터가 있을 경우 `includes` 메소드를 호출하며 발생하던 `TypeError`를 해결했습니다.
    - 각 필드의 존재 여부를 먼저 확인하는 방어 코드를 추가하여 필터링 로직의 안정성을 높였습니다.
