### PR TITLE
feat : 박람회 하위 관리자 프론트 연동 

### DIFF
--- a/src/api/service/expo-admin/operation/ManagerService.jsx
+++ b/src/api/service/expo-admin/operation/ManagerService.jsx
@@ -10,3 +10,14 @@ export const getMyExpoManagers = async (expoId) => {
     throw new Error(message);
   }
 };
+
+//관리자 정보 수정
+export const updateMyExpoManagers = async (expoId,data) => {
+  try {
+    const response = await instance.put(`/expos/${expoId}/managers`,data);
+    return response.data;
+  } catch (error) {
+    const message = error.response?.data?.message || "하위 관리자 정보 수정 중 오류 발생";
+    throw new Error(message);
+  }
+};

--- a/src/api/service/expo-admin/operation/ManagerService.jsx
+++ b/src/api/service/expo-admin/operation/ManagerService.jsx
@@ -1,0 +1,12 @@
+import instance from "../../../lib/axios";
+
+//관리자 정보 조회
+export const getMyExpoManagers = async (expoId) => {
+  try {
+    const response = await instance.get(`/expos/${expoId}/managers`);
+    return response.data;
+  } catch (error) {
+    const message = error.response?.data?.message || "하위 관리자 정보 조회 중 오류 발생";
+    throw new Error(message);
+  }
+};

--- a/src/api/service/expo-admin/permission/PermissionService.jsx
+++ b/src/api/service/expo-admin/permission/PermissionService.jsx
@@ -1,0 +1,12 @@
+import instance from "../../../lib/axios";
+
+//로그인한 사용자의 박람회 관리 권한 조회
+export const getMyPermission = async () => {
+  try {
+    const response = await instance.get(`/expos/my`);
+    return response.data;
+  } catch (error) {
+    const message = error.response?.data?.message || "권한 조회 중 오류 발생";
+    throw new Error(message);
+  }
+};

--- a/src/expo-admin/components/managerSection/ManagerSection.jsx
+++ b/src/expo-admin/components/managerSection/ManagerSection.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import styles from './ManagerSection.module.css';
-import { FaSave } from 'react-icons/fa';
+import { FaSave, FaSpinner } from 'react-icons/fa';
 import ToastSuccess from '../../../common/components/toastSuccess/ToastSuccess';
-import { FaSpinner } from 'react-icons/fa';
-import { getMyExpoManagers } from '../../../api/service/expo-admin/operation/ManagerService';
+import ToastFail from '../../../common/components/toastFail/ToastFail';
+import { getMyExpoManagers, updateMyExpoManagers } from '../../../api/service/expo-admin/operation/ManagerService';
 
 const permissionTabs = {
   '박람회 관리': ['isExpoDetailUpdate', 'isBoothInfoUpdate', 'isScheduleUpdate'],
@@ -27,23 +27,26 @@ const permissionLabels = {
 
 const permissionLabelsFlat = Object.values(permissionLabels);
 const permissionKeysFlat = Object.keys(permissionLabels);
-
 const loginAccountCode = '로그인계정';
 
 const processApiData = (apiData) => {
   const processedData = {};
   apiData.forEach(item => {
     const permissions = new Set();
-    for (const key in item.permissions) {
-      if (item.permissions[key] === true) {
+    permissionKeysFlat.forEach(key => {
+      if (item[key] === true) {
         permissions.add(permissionLabels[key]);
       }
-    }
-    processedData[item.adminCode] = permissions;
+    });
+    processedData[item.adminCode] = {
+      id: item.id,
+      permissions,
+    };
   });
-
-  processedData[loginAccountCode] = new Set(Object.values(permissionLabels));
-  
+  processedData[loginAccountCode] = {
+    id: null,
+    permissions: new Set(Object.values(permissionLabels)),
+  };
   return processedData;
 };
 
@@ -52,83 +55,91 @@ function ManagerSection() {
   const [permissionsByCode, setPermissionsByCode] = useState({});
   const [apiCodes, setApiCodes] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState(null);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
   const [showFailToast, setShowFailToast] = useState(false);
   const [failMessage, setFailMessage] = useState('');
 
-  //성공 토스트 팝업
   const triggerSuccessToast = () => {
     setShowSuccessToast(true);
     setTimeout(() => setShowSuccessToast(false), 5000);
   };
 
-  //성공 실패 팝업
   const triggerToastFail = (message) => {
     setFailMessage(message);
     setShowFailToast(true);
     setTimeout(() => setShowFailToast(false), 5000);
   };
 
-  //초기 렌더링
+  const fetchData = async () => {
+    try {
+      setIsLoading(true);
+      const data = await getMyExpoManagers(expoId);
+      const processedData = processApiData(data);
+      const fetchedCodes = data.map(item => item.adminCode);
+      const finalCodes = [loginAccountCode, ...fetchedCodes];
+      setPermissionsByCode(processedData);
+      setApiCodes(finalCodes);
+    } catch (err) {
+      triggerToastFail(err.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setIsLoading(true);
-        const data = await getMyExpoManagers(expoId);
-        const processedData = processApiData(data);
-        
-        const fetchedCodes = data.map(item => item.adminCode);
-
-        const finalCodes = [loginAccountCode, ...fetchedCodes];
-
-        setPermissionsByCode(processedData);
-        setApiCodes(finalCodes);
-        setError(null);
-      } catch (err) {
-        triggerToastFail(error.message);
-      } finally {
-        setIsLoading(false);
-      }
-    };
     fetchData();
   }, [expoId]);
 
   const togglePermission = (code, permission) => {
     if (code === loginAccountCode) return;
     setPermissionsByCode((prev) => {
-      const newSet = new Set(prev[code]);
+      const newSet = new Set(prev[code].permissions);
       newSet.has(permission) ? newSet.delete(permission) : newSet.add(permission);
-      return { ...prev, [code]: newSet };
+      return {
+        ...prev,
+        [code]: {
+          ...prev[code],
+          permissions: newSet,
+        },
+      };
     });
   };
 
-  const saveAll = () => {
+  const saveAll = async () => {
     const dataToSend = apiCodes
       .filter(code => code !== loginAccountCode)
       .map(code => {
-        const permissions = {};
+        const { id, permissions } = permissionsByCode[code];
+        const payload = { id, adminCode: code };
         permissionKeysFlat.forEach(key => {
-          permissions[key] = permissionsByCode[code]?.has(permissionLabels[key]) || false;
+          payload[key] = permissions?.has(permissionLabels[key]) || false;
         });
-        return {
-          adminCode: code,
-          permissions: permissions
-        };
+        return payload;
       });
-    triggerToast();
+
+    try {
+      const updatedData = await updateMyExpoManagers(expoId, dataToSend);
+      const processedData = processApiData(updatedData);
+      const fetchedCodes = updatedData.map(item => item.adminCode);
+      const finalCodes = [loginAccountCode, ...fetchedCodes];
+      setPermissionsByCode(processedData);
+      setApiCodes(finalCodes);
+      triggerSuccessToast();
+    } catch (error) {
+      triggerToastFail(error.message);
+    }
   };
 
   const getGroupClass = (index) => {
     const groupStarts = [0];
     Object.values(permissionTabs).reduce((sum, arr) => {
-        const nextSum = sum + arr.length;
-        groupStarts.push(nextSum);
-        return nextSum;
+      const nextSum = sum + arr.length;
+      groupStarts.push(nextSum);
+      return nextSum;
     }, 0);
     return groupStarts.includes(index) ? styles.groupStart : '';
   };
-  
+
   return (
     <div className={styles.container}>
       <div className={styles.headerControls}>
@@ -137,7 +148,7 @@ function ManagerSection() {
           저장
         </button>
       </div>
-      
+
       <div className={styles.tableWrapper}>
         <table className={styles.table}>
           <thead>
@@ -162,24 +173,33 @@ function ManagerSection() {
             </tr>
           </thead>
           <tbody>
-            {apiCodes.map((code) => (
-              <tr key={code}>
-                <td className={`${styles.td} ${styles.codeCell}`}>{code}</td>
-                {permissionLabelsFlat.map((label, idx) => (
-                  <td key={label} className={`${styles.td} ${getGroupClass(idx)}`}>
-                    <input
-                      type="checkbox"
-                      checked={permissionsByCode[code]?.has(label) || false}
-                      onChange={() => togglePermission(code, label)}
-                      disabled={code === loginAccountCode}
-                    />
-                  </td>
-                ))}
+            {isLoading ? (
+              <tr>
+                <td colSpan={permissionLabelsFlat.length + 1} className={styles.loadingRow}>
+                  <FaSpinner className={styles.spinner} /> 불러오는 중...
+                </td>
               </tr>
-            ))}
+            ) : (
+              apiCodes.map((code) => (
+                <tr key={code}>
+                  <td className={`${styles.td} ${styles.codeCell}`}>{code}</td>
+                  {permissionLabelsFlat.map((label, idx) => (
+                    <td key={label} className={`${styles.td} ${getGroupClass(idx)}`}>
+                      <input
+                        type="checkbox"
+                        checked={permissionsByCode[code]?.permissions?.has(label) || false}
+                        onChange={() => togglePermission(code, label)}
+                        disabled={code === loginAccountCode}
+                      />
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </div>
+
       {showSuccessToast && <ToastSuccess />}
       {showFailToast && <ToastFail message={failMessage} />}
     </div>

--- a/src/expo-admin/components/managerSection/ManagerSection.jsx
+++ b/src/expo-admin/components/managerSection/ManagerSection.jsx
@@ -1,37 +1,101 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import styles from './ManagerSection.module.css';
 import { FaSave } from 'react-icons/fa';
 import ToastSuccess from '../../../common/components/toastSuccess/ToastSuccess';
+import { FaSpinner } from 'react-icons/fa';
+import { getMyExpoManagers } from '../../../api/service/expo-admin/operation/ManagerService';
 
 const permissionTabs = {
-  '박람회 관리': ['박람회 상세', '참가 부스', '행사 일정'],
-  '예약 관리': ['예약자 리스트', '결제 내역', '이메일 전송 이력'],
-  '운영 설정': ['운영 설정'],
-  '기타': ['정산', '문의'],
+  '박람회 관리': ['isExpoDetailUpdate', 'isBoothInfoUpdate', 'isScheduleUpdate'],
+  '예약 관리': ['isReserverListView', 'isPaymentView', 'isEmailLogView'],
+  '운영 설정': ['isOperationsConfigUpdate'],
+  '기타': ['isSettlementView', 'isInquiryView'],
 };
 
-const codes = ['로그인계정', 'AB12CD', 'ZX98MN', 'JK34PO', 'YM77XZ', 'KT22LM'];
+const permissionLabels = {
+  isExpoDetailUpdate: '박람회 상세',
+  isBoothInfoUpdate: '참가 부스',
+  isScheduleUpdate: '행사 일정',
+  isReserverListView: '예약자 리스트',
+  isPaymentView: '결제 내역',
+  isEmailLogView: '이메일 전송 이력',
+  isOperationsConfigUpdate: '운영 설정',
+  isSettlementView: '정산',
+  isInquiryView: '문의',
+};
 
-const initialPermissions = {
-  로그인계정: new Set(Object.values(permissionTabs).flat()),
-  AB12CD: new Set(['박람회 관리', '참가 부스', '행사 일정', '정산']),
-  ZX98MN: new Set(['예약자 리스트', '이메일 전송 이력']),
-  JK34PO: new Set(['운영사 정보 수정', '담당자 관리']),
-  YM77XZ: new Set(['기본 설정', '이메일 전송 이력', '문의']),
-  KT22LM: new Set(['참가 부스', '정산', '문의']),
+const permissionLabelsFlat = Object.values(permissionLabels);
+const permissionKeysFlat = Object.keys(permissionLabels);
+
+const loginAccountCode = '로그인계정';
+
+const processApiData = (apiData) => {
+  const processedData = {};
+  apiData.forEach(item => {
+    const permissions = new Set();
+    for (const key in item.permissions) {
+      if (item.permissions[key] === true) {
+        permissions.add(permissionLabels[key]);
+      }
+    }
+    processedData[item.adminCode] = permissions;
+  });
+
+  processedData[loginAccountCode] = new Set(Object.values(permissionLabels));
+  
+  return processedData;
 };
 
 function ManagerSection() {
-  const [permissionsByCode, setPermissionsByCode] = useState(initialPermissions);
-  const [showToast, setShowToast] = useState(false);
+  const { expoId } = useParams();
+  const [permissionsByCode, setPermissionsByCode] = useState({});
+  const [apiCodes, setApiCodes] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [showSuccessToast, setShowSuccessToast] = useState(false);
+  const [showFailToast, setShowFailToast] = useState(false);
+  const [failMessage, setFailMessage] = useState('');
 
-  const triggerToast = () => {
-    setShowToast(true);
-    setTimeout(() => setShowToast(false), 2000);
+  //성공 토스트 팝업
+  const triggerSuccessToast = () => {
+    setShowSuccessToast(true);
+    setTimeout(() => setShowSuccessToast(false), 5000);
   };
 
+  //성공 실패 팝업
+  const triggerToastFail = (message) => {
+    setFailMessage(message);
+    setShowFailToast(true);
+    setTimeout(() => setShowFailToast(false), 5000);
+  };
+
+  //초기 렌더링
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setIsLoading(true);
+        const data = await getMyExpoManagers(expoId);
+        const processedData = processApiData(data);
+        
+        const fetchedCodes = data.map(item => item.adminCode);
+
+        const finalCodes = [loginAccountCode, ...fetchedCodes];
+
+        setPermissionsByCode(processedData);
+        setApiCodes(finalCodes);
+        setError(null);
+      } catch (err) {
+        triggerToastFail(error.message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchData();
+  }, [expoId]);
+
   const togglePermission = (code, permission) => {
-    if (code === '로그인계정') return;
+    if (code === loginAccountCode) return;
     setPermissionsByCode((prev) => {
       const newSet = new Set(prev[code]);
       newSet.has(permission) ? newSet.delete(permission) : newSet.add(permission);
@@ -40,38 +104,40 @@ function ManagerSection() {
   };
 
   const saveAll = () => {
-    codes.forEach((code) => {
-      if (code === '로그인계정') return;
-      const selected = Array.from(permissionsByCode[code]);
-      console.log(`📝 저장 - 코드 ${code}:`, selected);
-    });
-
-    triggerToast(); 
+    const dataToSend = apiCodes
+      .filter(code => code !== loginAccountCode)
+      .map(code => {
+        const permissions = {};
+        permissionKeysFlat.forEach(key => {
+          permissions[key] = permissionsByCode[code]?.has(permissionLabels[key]) || false;
+        });
+        return {
+          adminCode: code,
+          permissions: permissions
+        };
+      });
+    triggerToast();
   };
-
-  const permissionLabels = Object.values(permissionTabs).flat();
-  const groupBoundaries = Object.values(permissionTabs).map((arr) => arr.length);
 
   const getGroupClass = (index) => {
     const groupStarts = [0];
-    groupBoundaries.reduce((sum, len) => {
-      groupStarts.push(sum + len);
-      return sum + len;
+    Object.values(permissionTabs).reduce((sum, arr) => {
+        const nextSum = sum + arr.length;
+        groupStarts.push(nextSum);
+        return nextSum;
     }, 0);
     return groupStarts.includes(index) ? styles.groupStart : '';
   };
-
+  
   return (
     <div className={styles.container}>
-      {showToast && <ToastSuccess />}
-
       <div className={styles.headerControls}>
         <button className={`${styles.actionBtn} ${styles.saveBtn}`} onClick={saveAll}>
           <FaSave className={styles.icon} />
           저장
         </button>
       </div>
-
+      
       <div className={styles.tableWrapper}>
         <table className={styles.table}>
           <thead>
@@ -88,7 +154,7 @@ function ManagerSection() {
               ))}
             </tr>
             <tr>
-              {permissionLabels.map((label, idx) => (
+              {permissionLabelsFlat.map((label, idx) => (
                 <th key={label} className={`${styles.th} ${getGroupClass(idx)}`}>
                   {label}
                 </th>
@@ -96,16 +162,16 @@ function ManagerSection() {
             </tr>
           </thead>
           <tbody>
-            {codes.map((code) => (
+            {apiCodes.map((code) => (
               <tr key={code}>
                 <td className={`${styles.td} ${styles.codeCell}`}>{code}</td>
-                {permissionLabels.map((label, idx) => (
+                {permissionLabelsFlat.map((label, idx) => (
                   <td key={label} className={`${styles.td} ${getGroupClass(idx)}`}>
                     <input
                       type="checkbox"
                       checked={permissionsByCode[code]?.has(label) || false}
                       onChange={() => togglePermission(code, label)}
-                      disabled={code === '로그인계정'}
+                      disabled={code === loginAccountCode}
                     />
                   </td>
                 ))}
@@ -114,6 +180,8 @@ function ManagerSection() {
           </tbody>
         </table>
       </div>
+      {showSuccessToast && <ToastSuccess />}
+      {showFailToast && <ToastFail message={failMessage} />}
     </div>
   );
 }

--- a/src/expo-admin/components/operatorSection/OperatorSection.jsx
+++ b/src/expo-admin/components/operatorSection/OperatorSection.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import {
   FaUserTie, FaUserFriends, FaEnvelope, FaPhone,
-  FaMapMarkerAlt, FaBuilding, FaCheckCircle
+  FaMapMarkerAlt, FaBuilding, FaEdit
 } from 'react-icons/fa';
 import styles from './OperatorSection.module.css';
 import {
@@ -180,7 +180,7 @@ function OperatorSection() {
 
       <div className={styles.buttonGroup}>
         <button className={`${styles.actionBtn} ${styles.submitBtn}`} onClick={handleSubmit}>
-          <FaCheckCircle className={styles.iconBtn} /> 수정
+          <FaEdit className={styles.iconBtn} /> 수정
         </button>
       </div>
 

--- a/src/expo-admin/layout/ExpoAdminLayout.jsx
+++ b/src/expo-admin/layout/ExpoAdminLayout.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Outlet, useParams } from "react-router-dom";
+import { Outlet, useParams, useLocation } from "react-router-dom";
 import styles from './ExpoAdminLayout.module.css';
 import ExpoAdminHeader from "./header/ExpoAdminHeader";
 import ExpoAdminSideBar from "./sidebar/ExpoAdminSidebar";
@@ -7,18 +7,28 @@ import { usePermission } from "../permission/PermissionContext";
 
 function ExpoAdminLayout() {
   const { expoId } = useParams();
+  const location = useLocation();
   const { perm } = usePermission();
-  const [hasPermission, setHasPermission] = useState(null);
 
+  const [hasExpoAccess, setHasExpoAccess] = useState(null);
+
+  // 1) expoId 접근 권한(해당 박람회 소속 여부) 체크 및 직입 방지
   useEffect(() => {
     if (!perm) return;
     const expoIdNumber = Number(expoId);
-    setHasPermission(perm.expoIds.includes(expoIdNumber));
+    setHasExpoAccess(perm.expoIds.includes(expoIdNumber));
   }, [perm, expoId]);
 
-  if (hasPermission === null) return null;
+  if (hasExpoAccess === null) return null;
+  if (!hasExpoAccess) return <NoAccessPage />;
 
-  if (!hasPermission) return <NoAccessPage />; //권한 없음 페이지 렌더링
+  // 2) 페이지별 권한 체크 (주소창 직입 방지)
+  const basePath = `/expos/${expoId}/admin`;
+  const path = location.pathname;
+
+  const pageAllowed = hasPagePermission(path, basePath, perm);
+
+  if (!pageAllowed) return <NoAccessPage />;
 
   return (
     <div className={styles.layout}>
@@ -41,6 +51,28 @@ function ExpoAdminLayout() {
 
 export default ExpoAdminLayout;
 
+
+function hasPagePermission(path, basePath, perm) {
+  if (path === basePath || path === `${basePath}/`) return true;
+
+  const rules = [
+    { match: `${basePath}/setting`,      allow: !!perm?.isExpoDetailUpdate },
+    { match: `${basePath}/booths`,       allow: !!perm?.isBoothInfoUpdate },
+    { match: `${basePath}/events`,       allow: !!perm?.isScheduleUpdate },
+    { match: `${basePath}/payments`,     allow: !!perm?.isPaymentView },
+    { match: `${basePath}/reservations`, allow: !!perm?.isReserverListView },
+    { match: `${basePath}/emails`,       allow: !!perm?.isEmailLogView },
+    { match: `${basePath}/operation`,    allow: !!perm?.isOperationsConfigUpdate },
+    { match: `${basePath}/settlement`,   allow: !!perm?.isSettlementView },
+    { match: `${basePath}/inquiry`,      allow: !!perm?.isInquiryView },
+  ];
+
+  for (const r of rules) {
+    if (path.startsWith(r.match)) return r.allow;
+  }
+  return true;
+}
+
 function NoAccessPage() {
   return (
     <div style={{
@@ -52,12 +84,9 @@ function NoAccessPage() {
       textAlign: "center",
       padding: "2rem"
     }}>
-      <h2 style={{ fontSize: "1.75rem", color: "#d32f2f", marginBottom: "1rem" }}>
-        [403 Forbidden] 접근 권한이 없습니다
+      <h2 style={{ fontSize: "1.5rem", color: "#d32f2f", marginBottom: "1rem" }}>
+        [403 Forbidden] 접근 권한이 없습니다.
       </h2>
-      <p style={{ fontSize: "1rem", color: "#555" }}>
-        이 박람회에 대한 관리 권한이 없습니다.
-      </p>
     </div>
   );
 }

--- a/src/expo-admin/layout/ExpoAdminLayout.jsx
+++ b/src/expo-admin/layout/ExpoAdminLayout.jsx
@@ -3,25 +3,18 @@ import { Outlet, useParams } from "react-router-dom";
 import styles from './ExpoAdminLayout.module.css';
 import ExpoAdminHeader from "./header/ExpoAdminHeader";
 import ExpoAdminSideBar from "./sidebar/ExpoAdminSidebar";
-import { getMyExpos } from "../../api/service/expo-admin/AuthService";
+import { usePermission } from "../permission/PermissionContext";
 
 function ExpoAdminLayout() {
-  const [hasPermission, setHasPermission] = useState(null);
   const { expoId } = useParams();
+  const { perm } = usePermission();
+  const [hasPermission, setHasPermission] = useState(null);
 
   useEffect(() => {
-    const checkPermission = async () => {
-      try {
-        const expos = await getMyExpos(); //현재 로그인 한 사용자 기반으로 활성화된 exopId 반환
-        const expoIdNumber = Number(expoId);
-        setHasPermission(expos.includes(expoIdNumber));
-      } catch (error) {
-        console.error("권한 확인 실패:", error.message);
-        setHasPermission(false);
-      }
-    };
-    checkPermission();
-  }, [expoId]);
+    if (!perm) return;
+    const expoIdNumber = Number(expoId);
+    setHasPermission(perm.expoIds.includes(expoIdNumber));
+  }, [perm, expoId]);
 
   if (hasPermission === null) return null;
 

--- a/src/expo-admin/layout/sidebar/ExpoAdminSidebar.jsx
+++ b/src/expo-admin/layout/sidebar/ExpoAdminSidebar.jsx
@@ -1,31 +1,24 @@
-import {
-  Sidebar,
-  Menu,
-  MenuItem,
-  SubMenu,
-  sidebarClasses,
-  menuClasses,
-} from 'react-pro-sidebar';
-import { Link, useLocation, useParams } from 'react-router-dom';
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { Sidebar, Menu, MenuItem, SubMenu, sidebarClasses, menuClasses } from 'react-pro-sidebar';
+import { useLocation, useParams, useNavigate } from 'react-router-dom';
 import { AiOutlineBarChart } from 'react-icons/ai';
 import { MdEventNote } from 'react-icons/md';
 import { FiMessageSquare, FiSettings } from 'react-icons/fi';
 import { FaUserFriends } from 'react-icons/fa';
 import { BiMoneyWithdraw } from 'react-icons/bi';
-
+import { usePermission } from '../../permission/PermissionContext';
 import ExpoAdminInfoBox from '../../components/InfoBox/ExpoAdminInfoBox';
 
 function ExpoAdminSideBar() {
   const location = useLocation();
-  const { expoId } = useParams(); // ✅ 현재 expoId 추출
+  const navigate = useNavigate();
+  const { expoId } = useParams();
+  const { perm } = usePermission();
   const currentPath = location.pathname;
-
   const [selectedMenu, setSelectedMenu] = useState('');
   const [openSubMenus, setOpenSubMenus] = useState([]);
 
   const basePath = `/expos/${expoId}/admin`;
-
   const expoPaths = [`${basePath}/setting`, `${basePath}/booths`, `${basePath}/events`];
   const reservationPaths = [`${basePath}/payments`, `${basePath}/reservations`, `${basePath}/emails`];
 
@@ -46,6 +39,28 @@ function ExpoAdminSideBar() {
         ? prev.filter((key) => key !== menuKey)
         : [...prev, menuKey]
     );
+  };
+
+  const go = (path) => () => {
+    navigate(path);
+  };
+
+  const can = {
+    dashboard: true,
+    setting: !!perm?.isExpoDetailUpdate,
+    booths: !!perm?.isBoothInfoUpdate,
+    events: !!perm?.isScheduleUpdate,
+    payments: !!perm?.isPaymentView,
+    reservations: !!perm?.isReserverListView,
+    emails: !!perm?.isEmailLogView,
+    operation: !!perm?.isOperationsConfigUpdate,
+    settlement: !!perm?.isSettlementView,
+    inquiry: !!perm?.isInquiryView,
+  };
+
+  const disabledStyle = {
+    cursor: 'not-allowed',
+    color : '#838383ff'
   };
 
   return (
@@ -83,22 +98,22 @@ function ExpoAdminSideBar() {
           },
           [`.${menuClasses.subMenuRoot}`]: {
             backgroundColor: '#1e2a38',
-          }
+          },
         }}
       >
-        <MenuItem disabled style={{ cursor: 'default', opacity: '0.6' }}>
+        <MenuItem disabled style={{ cursor: 'default', opacity: 0.6 }}>
           Dashboards
         </MenuItem>
 
         <MenuItem
           icon={<AiOutlineBarChart />}
-          component={<Link to={`${basePath}`} />}
+          onClick={go(`${basePath}`)}
           active={selectedMenu === `${basePath}`}
         >
           대시 보드
         </MenuItem>
 
-        <MenuItem disabled style={{ cursor: 'default', opacity: '0.6' }}>
+        <MenuItem disabled style={{ cursor: 'default', opacity: 0.6 }}>
           Pages
         </MenuItem>
 
@@ -109,20 +124,28 @@ function ExpoAdminSideBar() {
           onOpenChange={() => toggleSubMenu('expo')}
         >
           <MenuItem
-            component={<Link to={`${basePath}/setting`} />}
+            onClick={can.setting ? go(`${basePath}/setting`) : undefined}
             active={selectedMenu === `${basePath}/setting`}
+            disabled={!can.setting}
+            style={!can.setting ? disabledStyle : {}}
           >
             박람회 상세
           </MenuItem>
+
           <MenuItem
-            component={<Link to={`${basePath}/booths`} />}
+            onClick={can.booths ? go(`${basePath}/booths`) : undefined}
             active={selectedMenu === `${basePath}/booths`}
+            disabled={!can.booths}
+            style={!can.booths ? disabledStyle : {}}
           >
             참가 부스
           </MenuItem>
+
           <MenuItem
-            component={<Link to={`${basePath}/events`} />}
+            onClick={can.events ? go(`${basePath}/events`) : undefined}
             active={selectedMenu === `${basePath}/events`}
+            disabled={!can.events}
+            style={!can.events ? disabledStyle : {}}
           >
             행사 일정
           </MenuItem>
@@ -135,20 +158,28 @@ function ExpoAdminSideBar() {
           onOpenChange={() => toggleSubMenu('reservation')}
         >
           <MenuItem
-            component={<Link to={`${basePath}/payments`} />}
+            onClick={can.payments ? go(`${basePath}/payments`) : undefined}
             active={selectedMenu === `${basePath}/payments`}
+            disabled={!can.payments}
+            style={!can.payments ? disabledStyle : {}}
           >
             예약 내역
           </MenuItem>
+
           <MenuItem
-            component={<Link to={`${basePath}/reservations`} />}
+            onClick={can.reservations ? go(`${basePath}/reservations`) : undefined}
             active={selectedMenu === `${basePath}/reservations`}
+            disabled={!can.reservations}
+            style={!can.reservations ? disabledStyle : {}}
           >
             예약자 리스트
           </MenuItem>
+
           <MenuItem
-            component={<Link to={`${basePath}/emails`} />}
+            onClick={can.emails ? go(`${basePath}/emails`) : undefined}
             active={selectedMenu === `${basePath}/emails`}
+            disabled={!can.emails}
+            style={!can.emails ? disabledStyle : {}}
           >
             이메일 전송 이력
           </MenuItem>
@@ -156,24 +187,30 @@ function ExpoAdminSideBar() {
 
         <MenuItem
           icon={<FiSettings />}
-          component={<Link to={`${basePath}/operation`} />}
+          onClick={can.operation ? go(`${basePath}/operation`) : undefined}
           active={selectedMenu === `${basePath}/operation`}
+          disabled={!can.operation}
+          style={!can.operation ? disabledStyle : {}}
         >
           운영 설정
         </MenuItem>
 
         <MenuItem
           icon={<BiMoneyWithdraw />}
-          component={<Link to={`${basePath}/settlement`} />}
+          onClick={can.settlement ? go(`${basePath}/settlement`) : undefined}
           active={selectedMenu === `${basePath}/settlement`}
+          disabled={!can.settlement}
+          style={!can.settlement ? disabledStyle : {}}
         >
           정산
         </MenuItem>
 
         <MenuItem
           icon={<FiMessageSquare />}
-          component={<Link to={`${basePath}/inquiry`} />}
+          onClick={can.inquiry ? go(`${basePath}/inquiry`) : undefined}
           active={selectedMenu === `${basePath}/inquiry`}
+          disabled={!can.inquiry}
+          style={!can.inquiry ? disabledStyle : {}}
         >
           문의
         </MenuItem>

--- a/src/expo-admin/permission/PermissionContext.jsx
+++ b/src/expo-admin/permission/PermissionContext.jsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import { getMyPermission } from "../../api/service/expo-admin/permission/PermissionService";
+
+// 1) 컨텍스트 생성
+const PermissionContext = createContext(null);
+
+// 2) Provider
+export function PermissionProvider({ children }) {
+  const [perm, setPerm] = useState(null);
+
+  // 권한 재로딩
+  const loadPermission  = async () => {
+    try {
+      const data = await getMyPermission();
+      setPerm(data ?? null);
+    } catch (e) {
+      console.error("권한 로드 실패:", e?.message || e);
+      setPerm(null);
+    }
+  };
+
+  // 최초 1회 로드
+  useEffect(() => {
+    loadPermission();
+  }, []);
+
+  return (
+    <PermissionContext.Provider value={{ perm }}>
+      {children}
+    </PermissionContext.Provider>
+  );
+}
+
+// 3) 사용 훅
+export function usePermission() {
+  const ctx = useContext(PermissionContext);
+  return ctx; // { perm }
+}

--- a/src/routes/ExpoAdminRoutes.jsx
+++ b/src/routes/ExpoAdminRoutes.jsx
@@ -1,4 +1,5 @@
 import { Routes, Route } from 'react-router-dom';
+import { PermissionProvider } from '../expo-admin/permission/PermissionContext';
 import ExpoAdminLayout from '../expo-admin/layout/ExpoAdminLayout';
 import Dashboard from '../expo-admin/pages/dashboard/Dashboard';
 import Payments from '../expo-admin/pages/payments/Payments';
@@ -13,6 +14,7 @@ import Inquiry from '../expo-admin/pages/inquiry/Inquiry';
 
 function ExpoAdminRoutes() {
   return (
+    <PermissionProvider>
       <Routes>
         <Route path="/expos/:expoId/admin" element={<ExpoAdminLayout />}>
           <Route index element={<Dashboard />} />
@@ -27,6 +29,7 @@ function ExpoAdminRoutes() {
           <Route path="inquiry" element={<Inquiry />} />
         </Route>
       </Routes>
+    </PermissionProvider>
   );
 }
 


### PR DESCRIPTION
### 박람회 하위 관리자 권한 조회/수정 기능 연동
- 박람회 하위 관리자의 권한 조회 및 수정 기능 연동하였습니다.

### 박람회 관리자 레이아웃 권한 체크 기능 추가

- 로그인한 사용자가 관리하는 박람회와 해당 박람회의 세부 권한을 레이아웃 진입 시 한 번만 체크하도록 구현했습니다.
- context를 사용하여 최초 진입 시 한 번만 API를 호출하고 반환된 권한 정보를 하위 페이지에서도 쉽게 활용할 수 있도록 했습니다.
- 하위 관리자의 경우 부여된 세부 페이지 권한에 따라 사이드바 메뉴가 비활성화(스타일 변경 및 클릭 불가) 되도록 처리했습니다.
- 권한이 없는 관리자 페이지에 주소창으로 직접 접근 시 403 Forbidden 권한 없음 페이지가 표시됩니다.

<img width="247" height="913" alt="image" src="https://github.com/user-attachments/assets/156117a6-81d8-44d1-b1c4-64a9c05db68b" />
