### PR TITLE
feat: 이용량 대시보드 화면 구현

### DIFF
--- a/src/api/service/platform-admin/dashboard/DashboardService.jsx
+++ b/src/api/service/platform-admin/dashboard/DashboardService.jsx
@@ -1,7 +1,13 @@
 import instance from "../../../lib/axios";
 
 export const getRevenue = async (activeTab) => {
-    return instance.get(`/dashboard/revenue`, {
+    return instance.get(`/platform/dashboard/revenue`, {
         params: { period: activeTab }
+    })
+};
+
+export const getUsage = async (activeTab) => {
+    return instance.get(`/platform/dashboard/usage`, {
+        params: {period: activeTab}
     })
 };

--- a/src/platform-admin/pages/platformDashboard/RevenueDashboard.jsx
+++ b/src/platform-admin/pages/platformDashboard/RevenueDashboard.jsx
@@ -72,6 +72,7 @@ function RevenueDashboard() {
 
   const chartOptions = {
     responsive: true,
+    maintainAspectRatio: false,
     plugins: {
       legend: {
         position: 'top',

--- a/src/platform-admin/pages/platformDashboard/UsageDashboard.jsx
+++ b/src/platform-admin/pages/platformDashboard/UsageDashboard.jsx
@@ -1,27 +1,124 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styles from './UsageDashboard.module.css';
 import { FiArrowUpRight, FiArrowDownRight } from 'react-icons/fi';
-import { FaFileExcel } from 'react-icons/fa';
 import ToastFail from '../../../common/components/toastFail/ToastFail';
+import Spinner from '../../../common/components/spinner/Spinner';
+import { getUsage } from '../../../api/service/platform-admin/dashboard/DashboardService';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+// chart.js의 필수 요소들을 등록합니다.
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+// DTO의 HashMap 키와 화면에 표시될 제목을 매핑합니다.
+const CHART_MAPPING = {
+  'expo': '총 행사',
+  'reservation': '총 예약',
+  'ad': '총 배너 신청',
+};
 
 function UsageDashboard() {
   const [activeTab, setActiveTab] = useState('weekly');
   const [showToast, setShowToast] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [summaryItems, setSummaryItems] = useState([]);
+  const [chartData, setChartData] = useState({}); // 차트 데이터를 저장할 상태
 
   const triggerToast = () => {
     setShowToast(true);
     setTimeout(() => setShowToast(false), 2500);
   };
 
+  useEffect(() => {
+    const fetchDashboardData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await getUsage(activeTab);
+        setSummaryItems(response.data.summaryItems); // DTO 변경에 따라 summaryItems 상태 업데이트
+        setChartData(response.data.chartData); // DTO 변경에 따라 chartData 상태 업데이트
+      } catch (err) {
+        console.error("Failed to fetch dashboard data:", err);
+        setError("데이터를 불러오는 데 실패했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    };
 
-  const summaryItems = [
-    { label: '현재 행사 수', value: '40,689', change: '+8.5%', trend: 'up' },
-    { label: '누적 예약 수', value: '1,622,000', change: '+1.3%', trend: 'up' },
-    { label: '', value: '10,534', change: '-4.3%', trend: 'down' },
-    { label: '현재 신청 행사', value: '2,381', change: '+1.8%', trend: 'up' },
-  ];
+    fetchDashboardData();
+  }, [activeTab]);
 
-  const chartTitles = ['총 행사', '총 예약', '총 행사 신청', '총 배너 신청'];
+  if (loading) {
+    return <Spinner />;
+  }
+
+  if (error) {
+    return <div className={styles.revenueContainer} style={{ color: 'red' }}>{error}</div>;
+  }
+
+  // Chart 컴포넌트 렌더링에 사용할 공통 옵션
+  const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false, // 이 옵션을 추가
+    plugins: {
+      legend: {
+        display: false,
+      },
+    },
+  };
+
+  const renderCharts = () => {
+    // chartData가 비어있거나, key-value 쌍이 없는 경우 null 반환
+    if (!chartData || Object.keys(chartData).length === 0) {
+      return null;
+    }
+
+    return Object.keys(CHART_MAPPING).map((key) => {
+      const data = chartData[key];
+      if (!data) return null; // 해당 키g에 대한 데이터가 없으면 렌더링하지 않음
+
+      const chartComponentData = {
+        labels: data.labels,
+        datasets: [
+          {
+            label: CHART_MAPPING[key], // 여기에 라벨을 추가합니다.
+            data: data.data,
+            borderColor: '#5B86E5', // 원하는 색상으로 변경
+            backgroundColor: 'rgba(91, 134, 229, 0.5)',
+            tension: 0.4,
+            fill: true,
+          },
+        ],
+      };
+
+      return (
+        <div key={key} className={styles.chartBlock}>
+          <p className={styles.chartTitle}>{CHART_MAPPING[key]}</p>
+          <div className={styles.chartPlaceholder}>
+            <Line options={chartOptions} data={chartComponentData} />
+          </div>
+        </div>
+      );
+    });
+  };
 
   return (
     <div className={styles.usageContainer}>
@@ -65,14 +162,14 @@ function UsageDashboard() {
         {summaryItems.map((item, index) => (
           <div key={index} className={styles.card}>
             <p className={styles.cardLabel}>{item.label}</p>
-            <p className={styles.cardValue}>{item.value}</p>
+            <p className={styles.cardValue}>{item.value.toLocaleString()}</p>
             <div className={styles.cardChange}>
-              {item.trend === 'up' ? (
+              {item.isTrending ? (
                 <FiArrowUpRight className={styles.upIcon} />
               ) : (
                 <FiArrowDownRight className={styles.downIcon} />
               )}
-              <span>{item.change} 지난 기간 대비</span>
+              <span>{item.change}% 지난 기간 대비</span>
             </div>
           </div>
         ))}
@@ -82,14 +179,8 @@ function UsageDashboard() {
         <h3>차트</h3>
       </div>
 
-      {/* 아래에 각각의 차트 섹션 추가 */}
       <div className={styles.chartSections}>
-        {chartTitles.map((title, idx) => (
-          <div key={idx} className={styles.chartBlock}>
-            <p className={styles.chartTitle}>{title}</p>
-            <div className={styles.chartPlaceholder}> {/* 여기에 차트 들어갈 자리 */} </div>
-          </div>
-        ))}
+        {renderCharts()}
       </div>
 
       {showToast && <ToastFail />}

--- a/src/platform-admin/pages/platformDashboard/UsageDashboard.module.css
+++ b/src/platform-admin/pages/platformDashboard/UsageDashboard.module.css
@@ -132,8 +132,9 @@
 }
 
 .chartPlaceholder {
-  height: 180px;
-  background-color: #f1f1f1;
+  width: 100%;
+  height:400px; 
+  background-color: #fff;
   border-radius: 8px;
 }
 
@@ -163,4 +164,11 @@
   background-color: #5b86e5;
   color: #fff;
   border-color: #5b86e5;
+}
+/* UsageDashboard.module.css */
+
+.chartPlaceholder {
+  /* 여기에 아래 코드를 추가하거나 수정 */
+  width: 100%; /* 부모 요소의 너비를 100%로 채웁니다. */
+  height: 300px; /* 차트 높이를 적절히 설정하여 공간을 확보합니다. */
 }


### PR DESCRIPTION
### 구현 사항
* 이용량 대시보드 구현
* 기간 당 누적 행사 수, 광고 수, 예약 수 요약
* 행사 / 광고 / 예약 추이 그래프
### 변경 사항
* api url을 /api/platform/dashboard/revenue,
           /api/platform/dashboard/usage
이상으로 바꿈