### PR TITLE
fix: 프론트엔드 전반적 수정

### DIFF
--- a/src/api/service/expo/expoDetailApi.js
+++ b/src/api/service/expo/expoDetailApi.js
@@ -38,6 +38,18 @@ export const getExpoBooths = async (expoId) => {
   return response.data;
 };
 
+// 박람회 비즈니스 프로필 조회
+export const getExpoBusinessProfile = async (expoId) => {
+  const response = await instance.get(`/expos/${expoId}/business-profile`);
+  return response.data;
+};
+
+// 박람회 이벤트 정보 조회
+export const getExpoEvents = async (expoId) => {
+  const response = await instance.get(`/expos/${expoId}/events`);
+  return response.data;
+};
+
 // 찜하기 토글 (추후 구현)
 export const toggleExpoBookmark = async (expoId) => {
   const response = await instance.post(`/expos/${expoId}/bookmark/toggle`);

--- a/src/expo-admin/pages/qrcheckin/QRCheckIn.jsx
+++ b/src/expo-admin/pages/qrcheckin/QRCheckIn.jsx
@@ -1,10 +1,55 @@
+import React, { useState } from 'react';
+import QRScannerComponent from '../../../components/qrScanner/QRScanner';
 import styles from './QRCheckIn.module.css';
 
-
 function QRCheckIn() {
+  const [showQRScanner, setShowQRScanner] = useState(false);
+
+  const handleOpenQRScanner = () => {
+    setShowQRScanner(true);
+  };
+
+  const handleCloseQRScanner = () => {
+    setShowQRScanner(false);
+  };
+
   return (
-    <div className={styles.settlementContainer}>
-      QR 체크인 관련해서 넣으세요
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <h1>QR 체크인</h1>
+        <p>박람회 입장객의 QR 티켓을 스캔하여 체크인을 처리합니다.</p>
+      </div>
+
+      <div className={styles.content}>
+        <div className={styles.scanSection}>
+          <div className={styles.scanIcon}>📱</div>
+          <h2>QR 코드 스캔</h2>
+          <p>입장객의 QR 티켓을 스캔하여 체크인하세요</p>
+          <button 
+            className={styles.scanBtn}
+            onClick={handleOpenQRScanner}
+          >
+            QR 스캔 시작
+          </button>
+        </div>
+
+        <div className={styles.instructions}>
+          <h3>체크인 안내</h3>
+          <ul>
+            <li>입장객이 제시하는 QR 코드를 카메라로 스캔합니다</li>
+            <li>유효한 티켓인지 자동으로 확인됩니다</li>
+            <li>체크인 완료 후 입장 허가 메시지가 표시됩니다</li>
+            <li>이미 사용된 티켓은 재사용할 수 없습니다</li>
+          </ul>
+        </div>
+      </div>
+
+      {/* QR 스캐너 모달 */}
+      {showQRScanner && (
+        <QRScannerComponent
+          onClose={handleCloseQRScanner}
+        />
+      )}
     </div>
   );
 }

--- a/src/expo-admin/pages/qrcheckin/QRCheckIn.module.css
+++ b/src/expo-admin/pages/qrcheckin/QRCheckIn.module.css
@@ -1,45 +1,121 @@
-/* --- Layout Container --- */
-.settlementContainer {
+.container {
+  padding: 20px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 40px;
+}
+
+.header h1 {
+  font-size: 2rem;
+  color: #333;
+  margin-bottom: 10px;
+}
+
+.header p {
+  color: #666;
+  font-size: 1.1rem;
+}
+
+.content {
   display: flex;
   flex-direction: column;
-  padding: 32px;
-  width: 100%;
+  gap: 30px;
 }
 
-/* 수평 배치용 */
-.sectionRow {
-  display: flex;
-  gap: 40px;
-  align-items: flex-start;
+.scanSection {
+  background: white;
+  border-radius: 12px;
+  padding: 40px;
+  text-align: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border: 2px solid #f0f0f0;
 }
 
-/* --- Section 공통 --- */
-.section {
-  width: 100%;
-  max-width: 600px;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  text-align: left;
+.scanIcon {
+  font-size: 4rem;
+  margin-bottom: 20px;
 }
 
-/* --- Title --- */
-.sectionTitle {
-  font-size: 20px;
-  font-weight: 700;
-  margin-bottom: 8px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.scanSection h2 {
+  font-size: 1.5rem;
+  color: #333;
+  margin-bottom: 10px;
 }
 
-/* --- NEW 뱃지 --- */
-.newBadge {
-  font-size: 10px;
-  font-weight: 600;
+.scanSection p {
+  color: #666;
+  margin-bottom: 30px;
+  font-size: 1rem;
+}
+
+.scanBtn {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
-  background-color: #ff3d51;
-  padding: 2px 8px;
-  border-radius: 10px;
-  text-transform: uppercase;
+  border: none;
+  padding: 15px 30px;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.scanBtn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
+}
+
+.instructions {
+  background: #f8f9ff;
+  border-radius: 12px;
+  padding: 30px;
+}
+
+.instructions h3 {
+  color: #333;
+  margin-bottom: 20px;
+  font-size: 1.2rem;
+}
+
+.instructions ul {
+  list-style: none;
+  padding: 0;
+}
+
+.instructions li {
+  color: #555;
+  padding: 10px 0;
+  border-bottom: 1px solid #e0e0e0;
+  position: relative;
+  padding-left: 25px;
+}
+
+.instructions li:last-child {
+  border-bottom: none;
+}
+
+.instructions li::before {
+  content: "✓";
+  color: #667eea;
+  font-weight: bold;
+  position: absolute;
+  left: 0;
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 15px;
+  }
+  
+  .scanSection {
+    padding: 30px 20px;
+  }
+  
+  .instructions {
+    padding: 20px;
+  }
 }

--- a/src/mainpage/pages/expoDetail/ExpoDetail.jsx
+++ b/src/mainpage/pages/expoDetail/ExpoDetail.jsx
@@ -8,6 +8,8 @@ import {
   getExpoReviews, 
   getExpoLocation,
   getExpoBooths,
+  getExpoBusinessProfile,
+  getExpoEvents,
   toggleExpoBookmark
 } from '../../../api/service/expo/expoDetailApi';
 import { FiBookmark, FiBookmark as FiBookmarkFill, FiMapPin, FiClock, FiUsers } from 'react-icons/fi';
@@ -21,7 +23,9 @@ export default function ExpoDetail() {
   const [reviews, setReviews] = useState(null);
   const [location, setLocation] = useState(null);
   const [booths, setBooths] = useState(null);
-  const [activeTab, setActiveTab] = useState('info'); // info, tickets, booths, reviews, location
+  const [businessProfile, setBusinessProfile] = useState(null);
+  const [events, setEvents] = useState(null);
+  const [activeTab, setActiveTab] = useState('info'); // info, tickets, booths, events, reviews, location
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [showPurchaseModal, setShowPurchaseModal] = useState(false);
@@ -44,7 +48,7 @@ export default function ExpoDetail() {
       setBasicInfo(basicData);
       
       // 다른 정보들도 병렬로 로드
-      const [ticketsData, bookmarkData, reviewsData, locationData, boothsData] = await Promise.all([
+      const [ticketsData, bookmarkData, reviewsData, locationData, boothsData, eventsData] = await Promise.all([
         getExpoTickets(expoId).catch(err => {
           console.error('티켓 정보 로드 실패:', err);
           return null;
@@ -64,6 +68,10 @@ export default function ExpoDetail() {
         getExpoBooths(expoId).catch(err => {
           console.error('부스 정보 로드 실패:', err);
           return null;
+        }),
+        getExpoEvents(expoId).catch(err => {
+          console.error('이벤트 정보 로드 실패:', err);
+          return null;
         })
       ]);
       
@@ -72,6 +80,7 @@ export default function ExpoDetail() {
       setReviews(reviewsData);
       setLocation(locationData);
       setBooths(boothsData);
+      setEvents(eventsData);
       
     } catch (err) {
       console.error('박람회 상세 정보 로드 실패:', err);
@@ -199,8 +208,7 @@ export default function ExpoDetail() {
             
             <div className={styles.detailItem}>
               <FiUsers className={styles.icon} />
-              <span>최대 {basicInfo.maxReserverCount?.toLocaleString()}명</span>
-              <span className={styles.current}>현재 {basicInfo.currentReservationCount?.toLocaleString()}명 예약</span>
+              <span>현재 {basicInfo.currentReservationCount?.toLocaleString()}명 예약</span>
             </div>
           </div>
           
@@ -210,23 +218,19 @@ export default function ExpoDetail() {
             ))}
           </div>
           
-          <div className={styles.organizer}>
-            <p><strong>주최:</strong> {basicInfo.organizerName}</p>
-            <p><strong>연락처:</strong> {basicInfo.organizerContact}</p>
-          </div>
 
           {/* 티켓 구매 섹션 */}
-          {tickets && tickets.length > 0 && (
-            <div className={styles.ticketPurchaseSection}>
-              <h3>티켓 구매</h3>
-              <div className={styles.ticketDropdownContainer}>
-                <select 
-                  className={styles.ticketSelect}
-                  value={selectedTicketId}
-                  onChange={(e) => setSelectedTicketId(e.target.value)}
-                >
-                  <option value="">티켓을 선택하세요</option>
-                  {tickets.map((ticket) => (
+          <div className={styles.ticketPurchaseSection}>
+            <h3>티켓 구매</h3>
+            <div className={styles.ticketDropdownContainer}>
+              <select 
+                className={styles.ticketSelect}
+                value={selectedTicketId}
+                onChange={(e) => setSelectedTicketId(e.target.value)}
+              >
+                <option value="">티켓을 선택하세요</option>
+                {tickets && tickets.length > 0 ? (
+                  tickets.map((ticket) => (
                     <option 
                       key={ticket.ticketId} 
                       value={ticket.ticketId}
@@ -234,18 +238,20 @@ export default function ExpoDetail() {
                     >
                       {ticket.name} - {ticket.price?.toLocaleString()}원 (남은 수량: {ticket.remainingQuantity?.toLocaleString()})
                     </option>
-                  ))}
-                </select>
-                <button 
-                  className={`${styles.purchaseBtn} ${!selectedTicketId ? styles.disabled : ''}`}
-                  disabled={!selectedTicketId}
-                  onClick={handleDropdownPurchase}
-                >
-                  구매하기
-                </button>
-              </div>
+                  ))
+                ) : (
+                  <option value="" disabled>등록된 티켓이 없습니다</option>
+                )}
+              </select>
+              <button 
+                className={`${styles.purchaseBtn} ${!selectedTicketId || !tickets || tickets.length === 0 ? styles.disabled : ''}`}
+                disabled={!selectedTicketId || !tickets || tickets.length === 0}
+                onClick={handleDropdownPurchase}
+              >
+                구매하기
+              </button>
             </div>
-          )}
+          </div>
         </div>
       </div>
 
@@ -270,6 +276,12 @@ export default function ExpoDetail() {
           부스 정보 ({booths?.length || 0})
         </button>
         <button 
+          className={`${styles.tab} ${activeTab === 'events' ? styles.active : ''}`}
+          onClick={() => setActiveTab('events')}
+        >
+          이벤트 ({events?.length || 0})
+        </button>
+        <button 
           className={`${styles.tab} ${activeTab === 'reviews' ? styles.active : ''}`}
           onClick={() => setActiveTab('reviews')}
         >
@@ -286,9 +298,30 @@ export default function ExpoDetail() {
       {/* 탭 컨텐츠 */}
       <div className={styles.tabContent}>
         {activeTab === 'info' && (
-          <div className={styles.description}>
-            <h3>상세 설명</h3>
-            <p>{basicInfo.description || '상세 설명이 없습니다.'}</p>
+          <div className={styles.infoTab}>
+            <div className={styles.description}>
+              <h3>상세 설명</h3>
+              <p>{basicInfo.description || '상세 설명이 없습니다.'}</p>
+            </div>
+            
+            {/* 주최자 정보 섹션 - 기본 정보에서 추출 */}
+            {basicInfo && (
+              <div className={styles.businessProfile}>
+                <h3>주최자 정보</h3>
+                <div className={styles.businessCard}>
+                  <div className={styles.businessHeader}>
+                    <h4>{basicInfo.organizerName || '주최자 정보 없음'}</h4>
+                  </div>
+                  <div className={styles.businessDetails}>
+                    {basicInfo.organizerContact && (
+                      <p className={styles.businessPhone}>
+                        📞 연락처: {basicInfo.organizerContact}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
         )}
         
@@ -363,6 +396,57 @@ export default function ExpoDetail() {
               </div>
             ) : (
               <p>등록된 부스가 없습니다.</p>
+            )}
+          </div>
+        )}
+        
+        {activeTab === 'events' && (
+          <div className={styles.eventsSection}>
+            <h3>이벤트 정보</h3>
+            {events && events.length > 0 ? (
+              <div className={styles.eventsList}>
+                {events.map((event) => (
+                  <div key={event.id} className={styles.eventCard}>
+                    <div className={styles.eventHeader}>
+                      <h4>{event.name}</h4>
+                      {event.location && (
+                        <div className={styles.eventLocationHeader}>📍 {event.location}</div>
+                      )}
+                    </div>
+                    <div className={styles.eventDateTime}>
+                      <div className={styles.eventDate}>
+                        📅 {formatDate(event.eventDate)}
+                      </div>
+                      <div className={styles.eventTime}>
+                        🕐 {formatTime(event.startTime)} - {formatTime(event.endTime)}
+                      </div>
+                    </div>
+                    <div className={styles.eventContent}>
+                      <p className={styles.eventDescription}>{event.description || '이벤트 설명이 없습니다.'}</p>
+                      
+                      <div className={styles.contactInfo}>
+                        {event.contactName && (
+                          <p className={styles.contactName}>
+                            👤 담당자: {event.contactName}
+                          </p>
+                        )}
+                        {event.contactPhone && (
+                          <p className={styles.contactPhone}>
+                            📞 연락처: {event.contactPhone}
+                          </p>
+                        )}
+                        {event.contactEmail && (
+                          <p className={styles.contactEmail}>
+                            📧 이메일: {event.contactEmail}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p>등록된 이벤트가 없습니다.</p>
             )}
           </div>
         )}

--- a/src/mainpage/pages/expoDetail/ExpoDetail.module.css
+++ b/src/mainpage/pages/expoDetail/ExpoDetail.module.css
@@ -682,3 +682,156 @@
     width: 100%;
   }
 }
+
+/* 정보 탭 */
+.infoTab {
+  padding: 20px 0;
+}
+
+.description {
+  margin-bottom: 40px;
+}
+
+.description h3 {
+  color: #333;
+  margin-bottom: 15px;
+  font-size: 20px;
+}
+
+.description p {
+  color: #666;
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+/* 비즈니스 프로필 */
+.businessProfile {
+  max-width: 600px;
+}
+
+.businessProfile h3 {
+  color: #333;
+  margin-bottom: 20px;
+  font-size: 18px;
+}
+
+.businessCard {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 20px;
+  background: #f9f9f9;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.businessHeader {
+  margin-bottom: 15px;
+  border-bottom: 1px solid #e0e0e0;
+  padding-bottom: 10px;
+}
+
+.businessHeader h4 {
+  margin: 0 0 5px 0;
+  color: #333;
+  font-size: 18px;
+}
+
+.businessNumber {
+  font-size: 12px;
+  color: #666;
+  background: #e9e9e9;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.businessDetails p {
+  margin: 8px 0;
+  font-size: 14px;
+  color: #555;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* 이벤트 섹션 - 부스와 동일한 스타일 */
+.eventsSection {
+  padding: 20px 0;
+}
+
+.eventsList {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.eventCard {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 20px;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.3s ease;
+}
+
+.eventCard:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.eventHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.eventHeader h4 {
+  margin: 0;
+  color: #333;
+  font-size: 18px;
+}
+
+.eventHeaderInfo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.eventNumber {
+  background: #f0f0f0;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  color: #666;
+}
+
+.eventLocation {
+  background: #e8f5e8;
+  padding: 3px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+  color: #2d5016;
+  font-weight: 500;
+}
+
+.eventContent {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.eventImage {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 6px;
+}
+
+.eventDescription {
+  color: #666;
+  line-height: 1.6;
+  margin: 0;
+}
+

--- a/src/mainpage/pages/payment/ExpoPayment.jsx
+++ b/src/mainpage/pages/payment/ExpoPayment.jsx
@@ -468,10 +468,6 @@ export default function ExpoPayment() {
               </span>
             </div>
             <div className={styles.row}>
-              <span>행사 가격</span>
-              <span>-</span>
-            </div>
-            <div className={styles.row}>
               <span>서비스 수수료</span>
               <span>
                 {quantity} x {SERVICE_FEE_PER_TICKET}

--- a/src/mypage/components/expoApplicationDetail/ExpoApplicationDetail.jsx
+++ b/src/mypage/components/expoApplicationDetail/ExpoApplicationDetail.jsx
@@ -11,6 +11,8 @@ function ExpoApplicationDetail({
   onRefundButtonClick,
   onSettlementRequestClick,
   onSettlementReceiptClick,
+  onPaymentInfoClick,
+  onAdminPageClick,
 }) {
   const [form, setForm] = useState({});
   const [isPremium, setIsPremium] = useState(false);
@@ -62,6 +64,16 @@ function ExpoApplicationDetail({
     }
   };
 
+  // 결제 정보를 볼 수 있는 상태인지 확인하는 함수 (승인대기, 결제대기, 게시대기 제외)
+  const canViewPaymentInfo = (status) => {
+    const excludedStatuses = [
+      '승인대기', '승인 대기',
+      '결제대기', '결제 대기', 
+      '게시대기', '게시 대기'
+    ];
+    return !excludedStatuses.includes(status);
+  };
+
   const renderButtons = () => {
     console.log('ExpoApplicationDetail - renderButtons, current status:', status);
     
@@ -83,6 +95,9 @@ function ExpoApplicationDetail({
           {(status === '게시대기' || status === '게시 대기' || status === '게시중' || status === '게시 중') && (
             <button className={`${styles.button} ${styles.receiptButton}`} onClick={onRefundButtonClick}>환불 신청</button>
           )}
+          {canViewPaymentInfo(status) && (
+            <button className={`${styles.button} ${styles.paymentInfoButton}`} onClick={onPaymentInfoClick}>결제 정보</button>
+          )}
         </div>
         
         {/* 상태별 주요 액션 버튼 */}
@@ -98,8 +113,12 @@ function ExpoApplicationDetail({
   const renderAdminButton = () => {
     if (status === '게시대기' || status === '게시 대기' || status === '게시중' || status === '게시 중' || status === '종료됨' || status === '정산요청' || status === '정산 요청') {
       return (
-        // 관리자 정보 버튼 클릭 시 onAdminInfoClick prop 호출
-        <button className={`${styles.adminButton}`} onClick={onAdminInfoClick}>관리자 정보</button>
+        <div className={styles.adminButtonGroup}>
+          {/* 관리자 정보 버튼 */}
+          <button className={`${styles.adminButton}`} onClick={onAdminInfoClick}>관리자 정보</button>
+          {/* 관리자 페이지로 이동 버튼 */}
+          <button className={`${styles.adminPageButton}`} onClick={onAdminPageClick}>관리자 페이지</button>
+        </div>
       );
     }
     return null;
@@ -221,42 +240,6 @@ function ExpoApplicationDetail({
         </div>
       </div>
       
-      {/* 예상 결제 정보 섹션 */}
-      <div className={`${styles.formGroup} ${styles.full}`}>
-        <label className={styles.label}>예상 결제 정보</label>
-        <div className={styles.paymentContainer}>
-          {form.paymentInfo ? (
-            <div className={styles.paymentGrid}>
-              {/* 프리미엄 여부에 따라 해당 등록금만 표시 */}
-              {isPremium ? (
-                <div className={styles.paymentItem}>
-                  <span className={styles.paymentLabel}>프리미엄 등록금</span>
-                  <span className={styles.paymentValue}>{form.paymentInfo.premiumDeposit?.toLocaleString()}원</span>
-                </div>
-              ) : (
-                <div className={styles.paymentItem}>
-                  <span className={styles.paymentLabel}>기본 등록금</span>
-                  <span className={styles.paymentValue}>{form.paymentInfo.deposit?.toLocaleString()}원</span>
-                </div>
-              )}
-              <div className={styles.paymentItem}>
-                <span className={styles.paymentLabel}>일일 사용료</span>
-                <span className={styles.paymentValue}>{form.paymentInfo.dailyUsageFee?.toLocaleString()}원</span>
-              </div>
-              <div className={styles.paymentItem}>
-                <span className={styles.paymentLabel}>총 게시 기간</span>
-                <span className={styles.paymentValue}>{form.paymentInfo.totalDay}일</span>
-              </div>
-              <div className={`${styles.paymentItem} ${styles.totalAmount}`}>
-                <span className={styles.paymentLabel}>총 결제 금액</span>
-                <span className={styles.paymentValue}>{form.paymentInfo.totalAmount?.toLocaleString()}원</span>
-              </div>
-            </div>
-          ) : (
-            <div className={styles.noPaymentInfo}>결제 정보가 없습니다.</div>
-          )}
-        </div>
-      </div>
       
       {/* 티켓 정보 섹션 */}
       <div className={`${styles.formGroup} ${styles.full}`}>
@@ -291,12 +274,6 @@ function ExpoApplicationDetail({
             <div className={styles.noTickets}>등록된 티켓이 없습니다.</div>
           )}
         </div>
-      </div>
-      <div className={`${styles.formGroup} ${styles.full}`}>
-          <label className={styles.label}>첨부파일</label>
-          <div className={styles.fileBox}>
-              <span className={styles.noAttachment}>첨부된 파일이 없습니다.</span>
-          </div>
       </div>
       
       {/* 하단 버튼 영역 - 환불 신청 버튼을 아래로 이동 */}

--- a/src/mypage/components/expoApplicationDetail/ExpoApplicationDetail.module.css
+++ b/src/mypage/components/expoApplicationDetail/ExpoApplicationDetail.module.css
@@ -102,6 +102,12 @@
   border-color: #d39e00;
 }
 
+.adminButtonGroup {
+  display: flex;
+  gap: 8px;
+  margin-left: 10px;
+}
+
 .adminButton {
   padding: 8px 16px;
   border: 1px solid #000;
@@ -112,7 +118,30 @@
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  margin-left: 10px;
+  font-size: 14px;
+}
+
+.adminButton:hover {
+  background-color: #f0f0f0;
+}
+
+.adminPageButton {
+  padding: 8px 16px;
+  border: 1px solid #667eea;
+  background-color: #667eea;
+  color: #fff;
+  font-weight: bold;
+  border-radius: 4px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  font-size: 14px;
+  transition: all 0.3s ease;
+}
+
+.adminPageButton:hover {
+  background-color: #5a6fd8;
+  border-color: #5a6fd8;
 }
 
 .topRow {
@@ -435,6 +464,20 @@
 .receiptButton:hover {
   background-color: #5a6268;
   border-color: #545b62;
+}
+
+.paymentInfoButton {
+  background-color: #3b82f6;
+  color: white;
+  border: 1px solid #3b82f6;
+  padding: 8px 16px;
+  font-size: 14px;
+  min-width: 100px;
+}
+
+.paymentInfoButton:hover {
+  background-color: #2563eb;
+  border-color: #2563eb;
 }
 
 /* 액션 버튼 그룹 */

--- a/src/mypage/components/paymentDetailModal/PaymentDetailModal.jsx
+++ b/src/mypage/components/paymentDetailModal/PaymentDetailModal.jsx
@@ -10,12 +10,15 @@ function PaymentDetailModal({
   dailyUsageFee,
   usageFeeAmount,
   depositAmount,
-  totalAmount,
+  premiumDepositAmount,
   isPremium,
-  commissionRate,
   children,
   onClose,
 }) {
+  // 총액 계산: 프리미엄일 경우 (기본 등록금 + 프리미엄 이용료 + 사용료), 기본일 경우 (기본 등록금 + 사용료)
+  const calculatedTotalAmount = isPremium 
+    ? (depositAmount || 0) + (premiumDepositAmount || 0) + (usageFeeAmount || 0)
+    : (depositAmount || 0) + (usageFeeAmount || 0);
   return (
     <div className={styles.modalOverlay}>
       <div className={styles.modalBox}>
@@ -49,18 +52,18 @@ function PaymentDetailModal({
               <span>{usageFeeAmount?.toLocaleString()}원</span>
             </div>
             <div className={styles.row}>
-              <span>{isPremium ? '프리미엄 등록금' : '기본 등록금'}</span>
+              <span>기본 등록금</span>
               <span>{depositAmount?.toLocaleString()}원</span>
             </div>
-            {commissionRate && (
+            {isPremium && premiumDepositAmount && (
               <div className={styles.row}>
-                <span>수수료율</span>
-                <span>{commissionRate}%</span>
+                <span>프리미엄 이용료</span>
+                <span>{premiumDepositAmount?.toLocaleString()}원</span>
               </div>
             )}
             <div className={styles.totalRow}>
               <span>총 결제 금액</span>
-              <span>{totalAmount?.toLocaleString()}원</span>
+              <span>{calculatedTotalAmount?.toLocaleString()}원</span>
             </div>
           </div>
         </div>

--- a/src/mypage/pages/expo-status/ExpoStatusPage.jsx
+++ b/src/mypage/pages/expo-status/ExpoStatusPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styles from './ExpoStatusPage.module.css';
 import { getMyExpos } from '../../../api/service/user/memberApi';
+import PaymentDetailModal from '../../components/paymentDetailModal/PaymentDetailModal';
 
 // 한 페이지에 보여줄 항목 수
 const ITEMS_PER_PAGE = 5;
@@ -16,6 +17,8 @@ const ExpoStatusPage = () => {
   const [totalPages, setTotalPages] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [showPaymentModal, setShowPaymentModal] = useState(false);
+  const [selectedPaymentData, setSelectedPaymentData] = useState(null);
 
   useEffect(() => {
     fetchMyExpos();
@@ -36,6 +39,7 @@ const ExpoStatusPage = () => {
         postPeriod: formatDateRange(expo.displayStartDate, expo.displayEndDate),
         location: expo.locationDetail ? `${expo.location} (${expo.locationDetail})` : expo.location,
         status: getStatusLabel(expo.status),
+        statusKey: expo.status, // 원본 상태 키 저장
         isPremium: expo.isPremium
       }));
       
@@ -60,17 +64,54 @@ const ExpoStatusPage = () => {
   const getStatusLabel = (status) => {
     const statusMap = {
       'PENDING_APPROVAL': '승인대기',
-      'PENDING_PAYMENT': '결제대기',
+      'PENDING_PAYMENT': '승인완료',
       'PENDING_PUBLISH': '게시대기',
       'PENDING_CANCEL': '취소대기',
       'PUBLISHED': '게시중',
       'PUBLISH_ENDED': '게시종료',
       'SETTLEMENT_REQUESTED': '정산요청',
       'COMPLETED': '종료됨',
-      'REJECTED': '거절됨',
-      'CANCELLED': '취소됨'
+      'REJECTED': '승인거절',
+      'CANCELLED': '취소완료'
     };
     return statusMap[status] || status;
+  };
+
+  // 결제 정보를 볼 수 있는 상태인지 확인하는 함수 (승인대기, 승인완료, 게시대기 제외)
+  const canViewPaymentInfo = (statusKey) => {
+    const excludedStatuses = [
+      'PENDING_APPROVAL', // 승인대기
+      'PENDING_PAYMENT',  // 승인완료 
+      'PENDING_PUBLISH'   // 게시대기
+    ];
+    return !excludedStatuses.includes(statusKey);
+  };
+
+  // 결제 정보 버튼 클릭 핸들러
+  const handlePaymentInfoClick = (e, expo) => {
+    e.stopPropagation(); // 행 클릭 이벤트 방지
+    
+    // 기존 PaymentDetailModal 형식에 맞는 데이터
+    const paymentData = {
+      expoName: expo.title,
+      applicant: '홍길동', // TODO: 실제 신청자 정보로 교체
+      period: expo.postPeriod,
+      totalDays: 30, // TODO: 실제 게시 일수로 교체
+      dailyUsageFee: expo.isPremium ? 30000 : 20000,
+      usageFeeAmount: expo.isPremium ? 900000 : 600000,
+      depositAmount: expo.isPremium ? 300000 : 200000,
+      totalAmount: expo.isPremium ? 1200000 : 800000,
+      isPremium: expo.isPremium,
+      commissionRate: 10
+    };
+    
+    setSelectedPaymentData(paymentData);
+    setShowPaymentModal(true);
+  };
+
+  const handleClosePaymentModal = () => {
+    setShowPaymentModal(false);
+    setSelectedPaymentData(null);
   };
 
   const handleRowClick = (expo) => {
@@ -188,6 +229,31 @@ const ExpoStatusPage = () => {
         </>
       ) : (
         <div className={styles.noData}>신청한 박람회가 없습니다.</div>
+      )}
+      
+      {/* 결제 상세 정보 모달 */}
+      {showPaymentModal && selectedPaymentData && (
+        <PaymentDetailModal
+          expoName={selectedPaymentData.expoName}
+          applicant={selectedPaymentData.applicant}
+          period={selectedPaymentData.period}
+          totalDays={selectedPaymentData.totalDays}
+          dailyUsageFee={selectedPaymentData.dailyUsageFee}
+          usageFeeAmount={selectedPaymentData.usageFeeAmount}
+          depositAmount={selectedPaymentData.depositAmount}
+          totalAmount={selectedPaymentData.totalAmount}
+          isPremium={selectedPaymentData.isPremium}
+          commissionRate={selectedPaymentData.commissionRate}
+          onClose={handleClosePaymentModal}
+        >
+          {/* 결제 버튼 없이 확인 버튼만 */}
+          <button 
+            className={styles.confirmBtn}
+            onClick={handleClosePaymentModal}
+          >
+            확인
+          </button>
+        </PaymentDetailModal>
       )}
     </div>
   );

--- a/src/mypage/pages/expo-status/ExpoStatusPage.module.css
+++ b/src/mypage/pages/expo-status/ExpoStatusPage.module.css
@@ -110,3 +110,57 @@
   color: #ffffff;
   border-color: #000000;
 }
+
+.paymentInfoBtn {
+  background-color: #3b82f6;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.paymentInfoBtn:hover {
+  background-color: #2563eb;
+  transform: translateY(-1px);
+}
+
+.premiumBadge {
+  background-color: #fbbf24;
+  color: #92400e;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  margin-left: 0.5rem;
+}
+
+.loading, .error, .noData {
+  text-align: center;
+  padding: 2rem;
+  font-size: 1rem;
+  color: #6b7280;
+}
+
+.error {
+  color: #dc2626;
+}
+
+.confirmBtn {
+  background-color: #6b7280;
+  color: white;
+  border: none;
+  padding: 0.75rem 2rem;
+  border-radius: 0.375rem;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.confirmBtn:hover {
+  background-color: #4b5563;
+}

--- a/src/mypage/pages/expoStatusDetail/ExpoStatusDetail.jsx
+++ b/src/mypage/pages/expoStatusDetail/ExpoStatusDetail.jsx
@@ -4,11 +4,12 @@ import ExpoApplicationDetail from '../../components/expoApplicationDetail/ExpoAp
 import PaymentWaitingModal from '../../components/paymentDetailModal/PaymentWaitingModal';
 import PaymentRefundModal from '../../components/paymentDetailModal/PaymentRefundModal';
 import SettlementReceiptModal from '../../components/paymentDetailModal/SettlementReceiptModal';
+import PaymentDetailModal from '../../components/paymentDetailModal/PaymentDetailModal';
 import AdminInfoModal from '../../components/adminInfoModal/AdminInfoModal';
-import QRScannerComponent from '../../../components/qrScanner/QRScanner';
 import styles from './ExpoStatusDetail.module.css';
 import PaymentSelection from '../payment-selection/PaymentSelection';
 import { getMyExpo, deleteMyExpo, getExpoRefundReceipt, getExpoAdminCodes, requestExpoSettlement, getExpoSettlementReceipt, getExpoPaymentDetail } from '../../../api/service/user/memberApi';
+import { useNavigate } from 'react-router-dom';
 
 // 상태 라벨 매핑
 const getStatusLabel = (status) => {
@@ -63,6 +64,7 @@ const safeNumber = (num, defaultValue = 0) => {
 
 const ExpoStatusDetail = () => {
   const { id } = useParams();
+  const navigate = useNavigate();
   const [expoData, setExpoData] = useState(null);
   const [modalType, setModalType] = useState(null);
   const [showPaymentSelection, setShowPaymentSelection] = useState(false);
@@ -73,9 +75,10 @@ const ExpoStatusDetail = () => {
   const [showSettlementReceiptModal, setShowSettlementReceiptModal] = useState(false);
   const [settlementReceiptData, setSettlementReceiptData] = useState(null);
   const [paymentDetailData, setPaymentDetailData] = useState(null);
+  const [showPaymentInfoModal, setShowPaymentInfoModal] = useState(false);
+  const [paymentInfoData, setPaymentInfoData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [showQRScanner, setShowQRScanner] = useState(false);
 
   useEffect(() => {
     if (id) {
@@ -279,14 +282,35 @@ const ExpoStatusDetail = () => {
     setSettlementReceiptData(null);
   };
 
-  // QR 스캔 모달 열기 핸들러
-  const handleOpenQRScanner = () => {
-    setShowQRScanner(true);
+
+  // 결제 정보 조회 핸들러
+  const handlePaymentInfoClick = async () => {
+    try {
+      setLoading(true);
+      const response = await getExpoPaymentDetail(id);
+      console.log('결제 정보 응답:', response.data);
+      console.log('isPremium:', response.data.isPremium);
+      console.log('depositAmount:', response.data.depositAmount);
+      console.log('premiumDepositAmount:', response.data.premiumDepositAmount);
+      setPaymentInfoData(response.data);
+      setShowPaymentInfoModal(true);
+    } catch (err) {
+      console.error('결제 정보 조회 실패:', err);
+      alert('결제 정보를 불러오는데 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
   };
 
-  // QR 스캔 모달 닫기 핸들러
-  const handleCloseQRScanner = () => {
-    setShowQRScanner(false);
+  // 결제 정보 모달 닫기 핸들러
+  const handleClosePaymentInfoModal = () => {
+    setShowPaymentInfoModal(false);
+    setPaymentInfoData(null);
+  };
+
+  // 관리자 페이지로 이동 핸들러
+  const handleAdminPageClick = () => {
+    navigate(`/expos/${id}/admin`);
   };
 
   if (loading) {
@@ -320,18 +344,6 @@ const ExpoStatusDetail = () => {
 
   return (
     <div className={styles.container}>
-      {/* QR 스캔 테스트 버튼 추가 */}
-      <div className={styles.qrScanSection}>
-        <button 
-          className={styles.qrScanButton} 
-          onClick={handleOpenQRScanner}
-        >
-          📱 QR 스캔 테스트
-        </button>
-        <p className={styles.qrScanNote}>
-          * 관리자 전용: 입장 QR 코드를 스캔하여 체크인 처리
-        </p>
-      </div>
 
       <ExpoApplicationDetail
         expoData={expoData}
@@ -341,6 +353,8 @@ const ExpoStatusDetail = () => {
         onRefundButtonClick={handleRefundButtonClick}
         onSettlementRequestClick={handleSettlementRequest}
         onSettlementReceiptClick={handleSettlementReceiptClick}
+        onPaymentInfoClick={handlePaymentInfoClick}
+        onAdminPageClick={handleAdminPageClick}
       />
 
       {modalType === 'waiting' && paymentDetailData && (
@@ -401,12 +415,29 @@ const ExpoStatusDetail = () => {
         />
       )}
 
-      {/* QR 스캐너 모달 조건부 렌더링 */}
-      {showQRScanner && (
-        <QRScannerComponent
-          onClose={handleCloseQRScanner}
-        />
+      {/* 결제 정보 모달 조건부 렌더링 */}
+      {showPaymentInfoModal && paymentInfoData && (
+        <PaymentDetailModal
+          expoName={paymentInfoData.expoTitle}
+          applicant={paymentInfoData.applicantName}
+          period={`${paymentInfoData.displayStartDate} ~ ${paymentInfoData.displayEndDate}`}
+          totalDays={paymentInfoData.totalDays}
+          dailyUsageFee={paymentInfoData.dailyUsageFee}
+          usageFeeAmount={paymentInfoData.usageFeeAmount}
+          depositAmount={paymentInfoData.depositAmount}
+          premiumDepositAmount={paymentInfoData.premiumDepositAmount}
+          isPremium={paymentInfoData.isPremium}
+          onClose={handleClosePaymentInfoModal}
+        >
+          <button 
+            className={styles.confirmBtn}
+            onClick={handleClosePaymentInfoModal}
+          >
+            확인
+          </button>
+        </PaymentDetailModal>
       )}
+
     </div>
   );
 };

--- a/src/mypage/pages/expoStatusDetail/ExpoStatusDetail.module.css
+++ b/src/mypage/pages/expoStatusDetail/ExpoStatusDetail.module.css
@@ -50,3 +50,19 @@
   font-size: 1.25rem;
   color: #6b7280;
 }
+
+.confirmBtn {
+  background-color: #6b7280;
+  color: white;
+  border: none;
+  padding: 0.75rem 2rem;
+  border-radius: 0.375rem;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.confirmBtn:hover {
+  background-color: #4b5563;
+}

--- a/src/mypage/pages/reservation/MyReservationPage.jsx
+++ b/src/mypage/pages/reservation/MyReservationPage.jsx
@@ -92,7 +92,7 @@ const MyReservationPage = () => {
       {reservations.length > 0 ? (
         <div className={styles.list}>
           {reservations.map((reservation) => (
-            <ReservationCard key={reservation.reservationCode} reservation={reservation} />
+            <ReservationCard key={reservation.reservationId} reservation={reservation} />
           ))}
         </div>
       ) : (

--- a/src/platform-admin/components/expoPaymentDetailModal/ExpoPaymentDetailModal.jsx
+++ b/src/platform-admin/components/expoPaymentDetailModal/ExpoPaymentDetailModal.jsx
@@ -3,6 +3,18 @@ import styles from './ExpoPaymentDetailModal.module.css';
 function ExpoPaymentDetailModal({ isOpen, onClose, paymentDetail }) {
   if (!isOpen) return null;
   
+  // 총액 계산: 프리미엄일 경우 (기본 등록금 + 프리미엄 이용료 + 사용료), 기본일 경우 (기본 등록금 + 사용료)
+  const calculateTotalAmount = (detail) => {
+    if (!detail) return 0;
+    const baseDeposit = detail.depositAmount || 0;
+    const usageFee = detail.usageFeeAmount || 0;
+    
+    if (detail.isPremium && detail.premiumDepositAmount) {
+      return baseDeposit + detail.premiumDepositAmount + usageFee;
+    }
+    return baseDeposit + usageFee;
+  };
+  
   if (!paymentDetail) {
     return (
       <div className={styles.modalOverlay}>
@@ -63,15 +75,23 @@ function ExpoPaymentDetailModal({ isOpen, onClose, paymentDetail }) {
             </span>
           </div>
           <div className={styles.row}>
-            <span className={styles.label}>보증금</span>
+            <span className={styles.label}>기본 등록금</span>
             <span className={styles.amount}>
               {paymentDetail.depositAmount?.toLocaleString()}원
             </span>
           </div>
+          {paymentDetail.isPremium && paymentDetail.premiumDepositAmount && (
+            <div className={styles.row}>
+              <span className={styles.label}>프리미엄 이용료</span>
+              <span className={styles.amount}>
+                {paymentDetail.premiumDepositAmount?.toLocaleString()}원
+              </span>
+            </div>
+          )}
           <div className={`${styles.row} ${styles.totalRow}`}>
             <span className={styles.totalLabel}>총 결제 금액</span>
             <span className={styles.totalAmount}>
-              {paymentDetail.totalAmount?.toLocaleString()}원
+              {calculateTotalAmount(paymentDetail)?.toLocaleString()}원
             </span>
           </div>
         </div>


### PR DESCRIPTION
      결제 신청 모달에서 수수료 삭제
      예상 결제 정보 삭제
      결제 정보 조회 버튼 추가

      행사 정보도 확인할수 있도록 수정
      티켓 없을시 티켓 구매 버튼 비활성화 대신 티켓 구매 드롭다운 클릭시 없다고 보여줘

      주최자랑 연락처정보 상세설명 칸으로 이관

      행사 가격 프론트에서 제거

      QR체크인 관리자 대시보드 창으로 이동
      마이페이지- 박람회 신청 내역에 관리자 페이지 이동 탭 추가