### PR TITLE
feat : 이메일 전송 이력 탭 구현

### DIFF
--- a/src/api/service/expo-admin/email/EmailService.jsx
+++ b/src/api/service/expo-admin/email/EmailService.jsx
@@ -1,0 +1,20 @@
+import instance from "../../../lib/axios";
+
+// 이메일 목록 조회
+export const getMyEmails = async (expoId, page, size, sort, keyword) => {
+  try {
+    const response = await instance.get(`/expos/${expoId}/emails`, {
+      params: {
+        page,
+        size,
+        sort,      
+        keyword,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    const message =
+      error.response?.data?.message || "이메일 목록 조회 중 오류 발생";
+    throw new Error(message);
+  }
+};

--- a/src/api/service/expo-admin/email/EmailService.jsx
+++ b/src/api/service/expo-admin/email/EmailService.jsx
@@ -18,3 +18,14 @@ export const getMyEmails = async (expoId, page, size, sort, keyword) => {
     throw new Error(message);
   }
 };
+
+//이메일 목록 상세 조회
+export const getMyEmailDetail = async (expoId, emailId) => {
+  try {
+    const response = await instance.get(`/expos/${expoId}/emails/${emailId}`);
+    return response.data;
+  } catch (error) {
+    const message = error.response?.data?.message || "이메일 목록 상세 조회 중 오류 발생";
+    throw new Error(message);
+  }
+};

--- a/src/expo-admin/components/emailTable/EmailTable.jsx
+++ b/src/expo-admin/components/emailTable/EmailTable.jsx
@@ -1,19 +1,44 @@
-import { useState } from 'react';
+import { useState, Fragment } from 'react';
 import styles from './EmailTable.module.css';
 
 const fieldLabelMap = {
   subject: '제목',
+  content: '내용',
   body: '내용',
+  recipientCount: '총 수신자',
   recipients: '총 수신자',
+  createdAt: '발송일시',
   sentAt: '발송일시',
   fileName: '첨부파일',
 };
 
-function EmailTable({ columns, data }) {
+// ✅ 누락된 날짜 키 집합 추가
+const DATE_KEYS = new Set(['createdAt', 'sentAt', 'updatedAt']);
+
+function formatDateTime(iso) {
+  if (!iso) return '-';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return String(iso);
+  const pad = (n) => String(n).padStart(2, '0');
+  const y = d.getFullYear();
+  const m = pad(d.getMonth() + 1);
+  const day = pad(d.getDate());
+  const hh = pad(d.getHours());
+  const mm = pad(d.getMinutes());
+  const ss = pad(d.getSeconds());
+  return `${y}-${m}-${day} ${hh}:${mm}:${ss}`;
+}
+
+function EmailTable({ columns, data, numbered = true, numberOffset = 0 }) {
   const [expandedRow, setExpandedRow] = useState(null);
 
   const handleRowClick = (index) => {
     setExpandedRow(expandedRow === index ? null : index);
+  };
+
+  const renderValue = (key, value) => {
+    if (DATE_KEYS.has(key)) return formatDateTime(value);
+    return value ?? '-';
   };
 
   return (
@@ -21,54 +46,60 @@ function EmailTable({ columns, data }) {
       <table className={styles.table}>
         <thead>
           <tr className={styles.headerRow}>
-            {columns.map((col, idx) => (
-              <th key={idx} className={styles.th}>
+            {numbered && (
+              <th className={styles.th} style={{ width: 64, textAlign: 'center' }}>
+                번호
+              </th>
+            )}
+            {columns.map((col) => (
+              <th key={col.key} className={styles.th}>
                 {col.header}
               </th>
             ))}
           </tr>
         </thead>
+
         <tbody>
-          {data.map((row, rowIndex) => (
-            <>
-              <tr
-                key={rowIndex}
-                className={styles.row}
-                onClick={() => handleRowClick(rowIndex)}
-              >
-                {columns.map((col, colIndex) => (
-                  <td
-                    key={colIndex}
-                    className={`${styles.td} ${
-                      col.key === 'body' ? styles.bodyCell : ''
-                    } ${col.groupStart ? styles.groupStart : ''} ${
-                      col.code ? styles.codeCell : ''
-                    }`}
-                  >
-                    {row[col.key]}
-                  </td>
-                ))}
-              </tr>
-              {expandedRow === rowIndex && (
-                <tr className={styles.detailRow}>
-                  <td colSpan={columns.length}>
-                    <div className={styles.detailBox}>
-                      {Object.entries(row).map(([key, value]) => (
-                        <div key={key} className={styles.detailItem}>
-                          <div className={styles.detailLabel}>
-                            {fieldLabelMap[key] || key}
-                          </div>
-                          <div className={styles.detailValue}>
-                            {value || '-'}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </td>
+          {data.map((row, rowIndex) => {
+            const rowKey = row.id ?? row._id ?? `row-${rowIndex}`;
+            return (
+              <Fragment key={rowKey}>
+                <tr className={styles.row} onClick={() => handleRowClick(rowIndex)}>
+                  {numbered && (
+                    <td className={styles.td} style={{ textAlign: 'center' }}>
+                      {numberOffset + rowIndex + 1}
+                    </td>
+                  )}
+
+                  {columns.map((col) => (
+                    <td
+                      key={col.key}
+                      className={`${styles.td} ${
+                        col.key === 'content' || col.key === 'body' ? styles.bodyCell : ''
+                      } ${col.groupStart ? styles.groupStart : ''} ${col.code ? styles.codeCell : ''}`}
+                    >
+                      {renderValue(col.key, row[col.key])}
+                    </td>
+                  ))}
                 </tr>
-              )}
-            </>
-          ))}
+
+                {expandedRow === rowIndex && (
+                  <tr className={styles.detailRow}>
+                    <td colSpan={columns.length + (numbered ? 1 : 0)}>
+                      <div className={styles.detailBox}>
+                        {Object.entries(row).map(([key, value]) => (
+                          <div key={key} className={styles.detailItem}>
+                            <div className={styles.detailLabel}>{fieldLabelMap[key] || key}</div>
+                            <div className={styles.detailValue}>{renderValue(key, value)}</div>
+                          </div>
+                        ))}
+                      </div>
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/src/expo-admin/components/emailTable/EmailTable.jsx
+++ b/src/expo-admin/components/emailTable/EmailTable.jsx
@@ -1,19 +1,18 @@
-import { useState, Fragment } from 'react';
+import { useState, useMemo, useEffect, Fragment } from 'react';
+import { useParams } from 'react-router-dom';
+import { getMyEmailDetail } from '../../../api/service/expo-admin/email/EmailService';
 import styles from './EmailTable.module.css';
 
 const fieldLabelMap = {
   subject: '제목',
   content: '내용',
-  body: '내용',
   recipientCount: '총 수신자',
   recipients: '총 수신자',
   createdAt: '발송일시',
-  sentAt: '발송일시',
-  fileName: '첨부파일',
 };
 
-// ✅ 누락된 날짜 키 집합 추가
-const DATE_KEYS = new Set(['createdAt', 'sentAt', 'updatedAt']);
+const DATE_KEYS = new Set(['createdAt']);
+const DISPLAY_LIMIT = 10; // 수신자 기본 표시 개수
 
 function formatDateTime(iso) {
   if (!iso) return '-';
@@ -29,16 +28,146 @@ function formatDateTime(iso) {
   return `${y}-${m}-${day} ${hh}:${mm}:${ss}`;
 }
 
-function EmailTable({ columns, data, numbered = true, numberOffset = 0 }) {
+function EmailTable({ columns, data }) {
+  const { expoId } = useParams();
   const [expandedRow, setExpandedRow] = useState(null);
-
-  const handleRowClick = (index) => {
-    setExpandedRow(expandedRow === index ? null : index);
-  };
+  const [detailMap, setDetailMap] = useState({});
+  const [showAllRecipientsMap, setShowAllRecipientsMap] = useState({});
 
   const renderValue = (key, value) => {
     if (DATE_KEYS.has(key)) return formatDateTime(value);
     return value ?? '-';
+  };
+
+  const dataSignature = useMemo(
+    () =>
+      (data || [])
+        .map((r) => r.id ?? r._id ?? `${r.createdAt ?? ''}-${r.subject ?? ''}-${r.fileName ?? ''}`)
+        .join('|'),
+    [data]
+  );
+
+  useEffect(() => {
+    setExpandedRow(null);
+    setDetailMap({});
+    setShowAllRecipientsMap({});
+  }, [dataSignature, expoId]);
+
+  const handleRowClick = async (rowIndex) => {
+    const next = expandedRow === rowIndex ? null : rowIndex;
+    setExpandedRow(next);
+    if (next === null) return;
+
+    const row = data[rowIndex];
+    const emailId = row.id ?? row._id;
+    if (!emailId) return;
+
+    if (detailMap[emailId]?.data || detailMap[emailId]?.loading) return;
+
+    if (!expoId) {
+      setDetailMap((prev) => ({
+        ...prev,
+        [emailId]: { loading: false, error: 'expoId가 없습니다.', data: null },
+      }));
+      return;
+    }
+
+    setDetailMap((prev) => ({
+      ...prev,
+      [emailId]: { loading: true, error: null, data: null },
+    }));
+
+    try {
+      const detail = await getMyEmailDetail(expoId, emailId);
+      setDetailMap((prev) => ({
+        ...prev,
+        [emailId]: { loading: false, error: null, data: detail },
+      }));
+    } catch (err) {
+      setDetailMap((prev) => ({
+        ...prev,
+        [emailId]: { loading: false, error: err?.message || '상세 조회 실패', data: null },
+      }));
+    }
+  };
+
+  const toggleRecipients = (emailId) => {
+    setShowAllRecipientsMap((prev) => ({ ...prev, [emailId]: !prev[emailId] }));
+  };
+
+  const renderDetailBox = (detail, emailId) => {
+    if (!detail) return null;
+    const { subject, content, recipientCount, recipientInfos = [], createdAt } = detail;
+
+    const showAll = !!showAllRecipientsMap[emailId];
+    const hiddenCount = Math.max(0, recipientInfos.length - DISPLAY_LIMIT);
+    const visibleList = showAll ? recipientInfos : recipientInfos.slice(0, DISPLAY_LIMIT);
+
+    return (
+      <div className={styles.detailBox}>
+        <div className={styles.detailItem}>
+          <div className={styles.detailLabel}>{fieldLabelMap.subject}</div>
+          <div className={styles.detailValue}>{subject ?? '-'}</div>
+        </div>
+
+        <div className={styles.detailItem}>
+          <div className={styles.detailLabel}>{fieldLabelMap.content}</div>
+          <div className={styles.detailValue} style={{ whiteSpace: 'pre-wrap' }}>
+            {content ?? '-'}
+          </div>
+        </div>
+
+        <div className={styles.detailItem}>
+          <div className={styles.detailLabel}>{fieldLabelMap.createdAt}</div>
+          <div className={styles.detailValue}>{formatDateTime(createdAt)}</div>
+        </div>
+
+        <div className={styles.detailItem}>
+          <div className={styles.detailLabel}>{fieldLabelMap.recipientCount}</div>
+          <div className={styles.detailValue}>{recipientCount ?? recipientInfos.length ?? 0}</div>
+        </div>
+
+        <div className={styles.detailItem}>
+          <div className={styles.detailLabel}>수신자 목록</div>
+          <div className={styles.detailValue}>
+            {recipientInfos.length === 0 ? (
+              '-'
+            ) : (
+              <>
+                <ul className={styles.recipientsList}>
+                  {visibleList.map((r, i) => (
+                    <li key={`${r.email}-${i}`}>
+                      {r.name ? `${r.name} ` : ''}
+                      <span style={{ color: '#6b7280' }}>{`<${r.email}>`}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                {hiddenCount > 0 && !showAll && (
+                  <button
+                    type="button"
+                    className={styles.moreBtn}
+                    onClick={() => toggleRecipients(emailId)}
+                  >
+                    외 {hiddenCount}명 더 보기
+                  </button>
+                )}
+
+                {showAll && recipientInfos.length > DISPLAY_LIMIT && (
+                  <button
+                    type="button"
+                    className={styles.moreBtn}
+                    onClick={() => toggleRecipients(emailId)}
+                  >
+                    접기
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    );
   };
 
   return (
@@ -46,11 +175,6 @@ function EmailTable({ columns, data, numbered = true, numberOffset = 0 }) {
       <table className={styles.table}>
         <thead>
           <tr className={styles.headerRow}>
-            {numbered && (
-              <th className={styles.th} style={{ width: 64, textAlign: 'center' }}>
-                번호
-              </th>
-            )}
             {columns.map((col) => (
               <th key={col.key} className={styles.th}>
                 {col.header}
@@ -62,15 +186,13 @@ function EmailTable({ columns, data, numbered = true, numberOffset = 0 }) {
         <tbody>
           {data.map((row, rowIndex) => {
             const rowKey = row.id ?? row._id ?? `row-${rowIndex}`;
+            const emailId = row.id ?? row._id;
+            const detailState = emailId ? detailMap[emailId] : undefined;
+            const isExpanded = expandedRow === rowIndex;
+
             return (
               <Fragment key={rowKey}>
                 <tr className={styles.row} onClick={() => handleRowClick(rowIndex)}>
-                  {numbered && (
-                    <td className={styles.td} style={{ textAlign: 'center' }}>
-                      {numberOffset + rowIndex + 1}
-                    </td>
-                  )}
-
                   {columns.map((col) => (
                     <td
                       key={col.key}
@@ -83,17 +205,17 @@ function EmailTable({ columns, data, numbered = true, numberOffset = 0 }) {
                   ))}
                 </tr>
 
-                {expandedRow === rowIndex && (
+                {isExpanded && (
                   <tr className={styles.detailRow}>
-                    <td colSpan={columns.length + (numbered ? 1 : 0)}>
-                      <div className={styles.detailBox}>
-                        {Object.entries(row).map(([key, value]) => (
-                          <div key={key} className={styles.detailItem}>
-                            <div className={styles.detailLabel}>{fieldLabelMap[key] || key}</div>
-                            <div className={styles.detailValue}>{renderValue(key, value)}</div>
-                          </div>
-                        ))}
-                      </div>
+                    <td colSpan={columns.length}>
+                      {detailState?.loading && <div className={styles.detailBox}>불러오는 중...</div>}
+                      {detailState?.error && (
+                        <div className={styles.detailBox} style={{ color: '#dc2626' }}>
+                          {detailState.error}
+                        </div>
+                      )}
+                      {detailState?.data && renderDetailBox(detailState.data, emailId)}
+                      {!detailState && <div className={styles.detailBox}>불러오는 중...</div>}
                     </td>
                   </tr>
                 )}

--- a/src/expo-admin/components/emailTable/EmailTable.module.css
+++ b/src/expo-admin/components/emailTable/EmailTable.module.css
@@ -103,3 +103,23 @@
 .saveBtn:hover {
   background-color: #4338ca;
 }
+
+.recipientsList {
+  margin: 0;
+  padding-left: 18px;
+  max-height: 200px;
+  overflow: auto;
+}
+
+.moreBtn {
+  margin-top: 8px;
+  padding: 6px 10px;
+  font-size: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+}
+.moreBtn:hover {
+  background: #f5f5f5;
+}

--- a/src/expo-admin/pages/emails/Emails.jsx
+++ b/src/expo-admin/pages/emails/Emails.jsx
@@ -1,69 +1,116 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { FiSearch } from 'react-icons/fi';
 import styles from './Emails.module.css';
 import EmailTable from '../../components/emailTable/EmailTable';
 import Pagination from '../../../common/components/pagination/Pagination';
+import ToastFail from '../../../common/components/toastFail/ToastFail';
+import ToastSuccess from '../../../common/components/toastSuccess/ToastSuccess';
+import { getMyEmails } from '../../../api/service/expo-admin/email/EmailService';
+
+const columns = [
+  { key: 'subject', header: '제목' },
+  { key: 'content', header: '내용' },
+  { key: 'recipientCount', header: '총 수신자' },
+  { key: 'createdAt', header: '발송일시' },
+];
 
 function Emails() {
+  const { expoId } = useParams();
+
   const [searchText, setSearchText] = useState('');
   const [sortOrder, setSortOrder] = useState('desc');
+
+  const [currentPage, setCurrentPage] = useState(0);
+  const [pageSize] = useState(10);
+
   const [pageInfo, setPageInfo] = useState({
-    content: [
-      {
-        subject: '박람회 안내 메일',
-        body: '안녕하세요, 서울 스마트 모빌리티 엑스포에 참여해주셔서 감사합니다. 본 메일은 안내 목적으로 발송되었습니다. 진짜 졸려 뒤지기겠다 정말로요... 졸리지만 멈출완전 짜증난다 진짜 개졸리다 자면 6시일듯',
-        recipients: 36,
-        sentAt: '2025-08-01 14:23:45',
-        fileName: 'expo_guide.pdf'
-      },
-      {
-        subject: '이벤트 당첨자 발표',
-        body: '축하드립니다! 귀하는 2025 엑스포 이벤트에 당첨되셨습니다. 자세한 사항은 첨부파일을 확인해주세요.',
-        recipients: 12,
-        sentAt: '2025-07-28 09:12:00',
-        fileName: ''
-      }
-    ],
-    totalPages: 1,
-    totalElements: 2,
-    size: 10,
-    number: 0,
+    content: [],
+    totalPages: 0,
+    number: 0,  
+    size: pageSize,
+    totalElements: 0,
   });
 
-  const handlePageChange = (page) => {
-    setPageInfo((prev) => ({
-      ...prev,
-      number: page,
-      content: prev.content,
-    }));
+  // 토스트
+  const [showSuccessToast, setShowSuccessToast] = useState(false);
+  const [showFailToast, setShowFailToast] = useState(false);
+  const [failMessage, setFailMessage] = useState('');
+
+  //이메일 목록 조회
+  const fetchEmails = async () => {
+    try {
+      const keywordParam = searchText.trim() || undefined;
+
+      const res = await getMyEmails(
+        expoId,
+        currentPage,
+        pageSize,
+        sortOrder,
+        keywordParam
+      );
+
+      setPageInfo({
+        content: res.content ?? [],
+        totalPages: res.page?.totalPages ?? 0,
+        number: res.page?.number ?? currentPage,
+        size: res.page?.size ?? pageSize,
+        totalElements: res.page?.totalElements ?? 0,
+      });
+    } catch (error) {
+      triggerToastFail(error.message);
+    }
   };
 
-  const columns = [
-    { key: 'subject', header: '제목' },
-    { key: 'body', header: '내용' },
-    { key: 'recipients', header: '총 수신자' },
-    { key: 'sentAt', header: '발송일시' },
-  ];
+  useEffect(() => {
+    fetchEmails();
+  }, [expoId, currentPage, pageSize, sortOrder, searchText]);
+
+  const handlePageChange = (page) => {
+    setCurrentPage(page);
+  };
+
+  // 성공 토스트
+  const triggerSuccessToast = () => {
+    setShowSuccessToast(true);
+    setTimeout(() => setShowSuccessToast(false), 3000);
+  };
+
+  // 실패 토스트
+  const triggerToastFail = (message) => {
+    setFailMessage(message);
+    setShowFailToast(true);
+    setTimeout(() => setShowFailToast(false), 3000);
+  };
 
   return (
     <div className={styles.emailsWrapper}>
+      {/* 상단 필터 영역 */}
       <div className={styles.topControls}>
         <div className={styles.filters}>
+          {/* 검색어 입력 */}
           <div className={styles.filterGroup}>
             <input
               type="text"
               value={searchText}
-              onChange={(e) => setSearchText(e.target.value)}
+              onChange={(e) => {
+                setSearchText(e.target.value);
+                setCurrentPage(0);
+              }}
               placeholder="제목 또는 내용 검색"
               className={styles.input}
             />
             <FiSearch className={styles.searchIcon} />
           </div>
 
+          {/* 정렬 */}
           <div className={styles.filterGroup}>
             <select
               value={sortOrder}
-              onChange={(e) => setSortOrder(e.target.value)}
+              onChange={(e) => {
+                setSortOrder(e.target.value);
+                setCurrentPage(0);
+              }}
               className={styles.select}
             >
               <option value="desc">최신순</option>
@@ -74,10 +121,19 @@ function Emails() {
       </div>
 
       {/* 테이블 */}
-      <EmailTable columns={columns} data={pageInfo.content} />
+      <EmailTable
+      columns={columns}
+      data={pageInfo.content}
+      numbered
+      numberOffset={pageInfo.number * pageInfo.size}
+      />
 
       {/* 페이징 */}
       <Pagination pageInfo={pageInfo} onPageChange={handlePageChange} />
+
+      {/* 토스트 */}
+      {showSuccessToast && <ToastSuccess />}
+      {showFailToast && <ToastFail message={failMessage} />}
     </div>
   );
 }


### PR DESCRIPTION
<img width="1624" height="811" alt="image" src="https://github.com/user-attachments/assets/5b0c3765-e13b-470f-9eb4-9c77de7d68e6" />
- 이메일 전송 이력 프론트를 연동하였습니다.
- 이메일 제목과 내용으로 검색 및, 발송일시 기준으로 최신순/오래된순 정렬이 가능합니다. 
- 기본 목록 조회에서는 간단한 정보만 보이며, 해당 row를 클릭 시 detail한 정보를 불러오는 api를 호출합니다.
- 수신자 목록은 기본으로 상위 10명까지만 보이며 더보기 버튼 클릭시 모든 수신사 목록 확인이 가능합니다.
- 내부 스크롤이 되도록 구현하여 페이지가 넘치지 않도록했습니다.