### PR TITLE
feat: 박람회 카테고리, 박람회 상태 수정

### DIFF
--- a/src/expo-admin/components/boothTable/BoothTable.jsx
+++ b/src/expo-admin/components/boothTable/BoothTable.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { useState } from 'react';
 import styles from './BoothTable.module.css';
-import ToastSuccess from '../../../common/components/toastSuccess/ToastSuccess';
-
-const DEFAULT_IMAGE = 'https://via.placeholder.com/240x180?text=No+Image';
+import ImageUpload from '../../../common/components/imageUpload/ImageUpload';
+import ToggleSwitch from '../../../common/components/toggleSwitch/ToggleSwitch';
 
 const fieldLabelMap = {
   name: '부스명',
@@ -19,7 +18,6 @@ const boothFields = [
   'name',
   'description', 
   'boothNumber',
-  'displayRank',
 ];
 
 const contactFields = [
@@ -31,11 +29,6 @@ const contactFields = [
 function BoothTable({ data = [], onDelete, onUpdate }) {
   const [expandedId, setExpandedId] = useState(null);
   const [editForm, setEditForm] = useState(null);
-  const [showToast, setShowToast] = useState(false);
-  const triggerToast = () => {
-    setShowToast(true);
-    setTimeout(() => setShowToast(false), 2500);
-  };
 
   const handleRowClick = (row) => {
     if (expandedId === row.id) {
@@ -52,9 +45,33 @@ function BoothTable({ data = [], onDelete, onUpdate }) {
     setEditForm((prev) => ({ ...prev, [name]: value }));
   };
 
+  const handleImageUploadSuccess = (imageUrl) => {
+    setEditForm((prev) => ({ ...prev, mainImageUrl: imageUrl }));
+  };
+
+  const handleImageUploadError = (error) => {
+    console.error('이미지 업로드 실패:', error);
+  };
+
+  const handlePremiumToggle = (checked) => {
+    setEditForm((prev) => ({
+      ...prev,
+      isPremium: checked,
+      displayRank: checked ? prev.displayRank : '',
+    }));
+  };
+
   const handleSave = () => {
-    onUpdate(editForm);
-    triggerToast();
+    // 프리미엄 부스가 아닌 경우 displayRank를 null로 설정
+    const payload = {
+      ...editForm,
+      displayRank: editForm.isPremium 
+        ? parseInt(editForm.displayRank || '0', 10) 
+        : null,
+    };
+    
+    onUpdate(payload);
+    // 부모에서 토스트 관리하므로 여기서는 토스트 띄우지 않음
   };
 
   const handleDeleteClick = (e, id) => {
@@ -79,8 +96,6 @@ function BoothTable({ data = [], onDelete, onUpdate }) {
 
   return (
     <div className={styles.tableWrapper}>
-      {showToast && <ToastSuccess />}
-
       <table className={styles.table}>
         <thead>
           <tr className={styles.headerRow}>
@@ -127,16 +142,26 @@ function BoothTable({ data = [], onDelete, onUpdate }) {
                   <tr key={`detail-${row.id}`} className={styles.detailRow}>
                     <td colSpan={columns.length + 1}>
                       <div className={styles.detailBox}>
-                        <div className={styles.detailGrid}>
-                          {/* 부스 정보 */}
-                          <div className={styles.column}>
+                        <div className={styles.topRow}>
+                          {/* 썸네일 이미지 */}
+                          <div className={styles.imageWrapper}>
+                            <ImageUpload
+                              initialImageUrl={editForm.mainImageUrl}
+                              onUploadSuccess={handleImageUploadSuccess}
+                              onUploadError={handleImageUploadError}
+                            />
+                          </div>
+                        
+                          <div className={styles.detailGrid}>
+                            {/* 부스 정보 */}
+                            <div className={styles.column}>
                             {boothFields.map((key) => (
                               <div key={key} className={styles.detailItem}>
                                 <div className={styles.detailLabel}>
                                   {fieldLabelMap[key]}
                                 </div>
                                 <input
-                                  type={key === 'displayRank' ? 'number' : 'text'}
+                                  type="text"
                                   name={key}
                                   value={editForm[key] || ''}
                                   onChange={handleChange}
@@ -144,6 +169,32 @@ function BoothTable({ data = [], onDelete, onUpdate }) {
                                 />
                               </div>
                             ))}
+                            
+                            {/* 프리미엄 부스 토글 */}
+                            <div className={styles.detailItem}>
+                              <div className={styles.detailLabel}>프리미엄 부스</div>
+                              <div className={styles.booleanGroup}>
+                                <ToggleSwitch
+                                  checked={editForm.isPremium || false}
+                                  onChange={handlePremiumToggle}
+                                />
+                              </div>
+                            </div>
+                            
+                            {/* 조건부 노출 순위 */}
+                            {editForm.isPremium && (
+                              <div className={styles.detailItem}>
+                                <div className={styles.detailLabel}>노출 순위</div>
+                                <input
+                                  type="number"
+                                  name="displayRank"
+                                  value={editForm.displayRank || ''}
+                                  onChange={handleChange}
+                                  placeholder="노출 순위 (1~100)"
+                                  className={styles.inputField}
+                                />
+                              </div>
+                            )}
                           </div>
 
                           {/* 담당자 정보 */}
@@ -161,6 +212,7 @@ function BoothTable({ data = [], onDelete, onUpdate }) {
                                 />
                               </div>
                             ))}
+                            </div>
                           </div>
                         </div>
 

--- a/src/expo-admin/components/boothTable/BoothTable.module.css
+++ b/src/expo-admin/components/boothTable/BoothTable.module.css
@@ -53,6 +53,25 @@
   font-size: 14px;
 }
 
+.topRow {
+  display: flex;
+  gap: 24px;
+  align-items: flex-start;
+}
+
+.detailGrid {
+  flex: 1;
+  display: flex;
+  gap: 24px;
+}
+
+.column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 .imageWrapper {
   display: flex;
   justify-content: flex-start;
@@ -100,6 +119,13 @@
   font-size: 13px;
   color: #888;
   font-weight: 500;
+}
+
+.booleanGroup {
+  display: flex;
+  gap: 12px;
+  margin-top: 9px;
+  align-items: center;
 }
 
 .inputField {

--- a/src/expo-admin/components/eventTable/EventTable.jsx
+++ b/src/expo-admin/components/eventTable/EventTable.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useState } from 'react';
-import ToastSuccess from '../../../common/components/toastSuccess/ToastSuccess';
 import styles from './EventTable.module.css';
 
 const fieldLabelMap = {
@@ -33,12 +32,6 @@ const managerFields = [
 function EventTable({ data = [], onUpdate, onDelete }) {
   const [expandedId, setExpandedId] = useState(null);
   const [editForm, setEditForm] = useState(null);
-  const [showToast, setShowToast] = useState(false);
-
-  const triggerToast = () => {
-    setShowToast(true);
-    setTimeout(() => setShowToast(false), 2500);
-  };
 
   const handleRowClick = (row) => {
     if (expandedId === row.id) {
@@ -57,7 +50,7 @@ function EventTable({ data = [], onUpdate, onDelete }) {
 
   const handleSave = () => {
     onUpdate(editForm);
-    triggerToast();
+    // 부모에서 토스트 관리하므로 여기서는 토스트 띄우지 않음
   };
 
   const handleDeleteClick = (e, id) => {
@@ -85,8 +78,6 @@ function EventTable({ data = [], onUpdate, onDelete }) {
 
   return (
     <div className={styles.tableWrapper}>
-      {showToast && <ToastSuccess />}
-
       <table className={styles.table}>
         <thead>
           <tr className={styles.headerRow}>

--- a/src/expo-admin/components/expoSettingForm/ExpoSettingForm.jsx
+++ b/src/expo-admin/components/expoSettingForm/ExpoSettingForm.jsx
@@ -9,6 +9,7 @@ import {
   getMyExpoInfo,
   updateMyExpoInfo,
 } from '../../../api/service/expo-admin/setting/ExpoInfoService';
+import { getCategories } from '../../../api/service/user/categoryApi';
 import ImageUpload from '../../../common/components/imageUpload/ImageUpload';
 
 function ExpoSettingForm() {
@@ -18,6 +19,7 @@ function ExpoSettingForm() {
   const [showToast, setShowToast] = useState(false);
   const [showFailToast, setShowFailToast] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+  const [categories, setCategories] = useState([]);
 
   function initForm() {
     return {
@@ -68,8 +70,31 @@ function ExpoSettingForm() {
     }
   };
 
+  const fetchCategories = async () => {
+    try {
+      const data = await getCategories();
+      setCategories(data);
+    } catch (error) {
+      console.error('Failed to fetch categories:', error);
+    }
+  };
+
+  const getCategoryNames = (categoryIds) => {
+    if (!categoryIds || categoryIds.length === 0) return '카테고리 없음';
+    
+    const categoryNames = categoryIds
+      .map(id => {
+        const category = categories.find(cat => cat.id === id);
+        return category ? category.name : `ID: ${id}`;
+      })
+      .filter(name => name);
+    
+    return categoryNames.length > 0 ? categoryNames.join(', ') : '카테고리 없음';
+  };
+
   useEffect(() => {
     fetchExpoInfo();
+    fetchCategories();
   }, [expoId]);
 
   const handleChange = (e) => {
@@ -290,13 +315,10 @@ function ExpoSettingForm() {
           </div>
 
           <div className={`${styles.formGroup} ${styles.full}`}>
-            <label className={styles.label}>상태 및 카테고리</label>
+            <label className={styles.label}>카테고리</label>
             <div className={styles.badgeRow}>
-              <div className={`${styles.badge} ${styles.red}`}>
-                {form.status || '상태 없음'}
-              </div>
               <div className={styles.badge}>
-                {form.categoryIds.join(', ') || '카테고리 없음'}
+                {getCategoryNames(form.categoryIds)}
               </div>
             </div>
           </div>

--- a/src/expo-admin/pages/setting/Setting.jsx
+++ b/src/expo-admin/pages/setting/Setting.jsx
@@ -1,13 +1,51 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import styles from './Setting.module.css';
 import ExpoSettingForm from '../../components/expoSettingForm/ExpoSettingForm';
 import TicketSettingForm from '../../components/ticketSettingForm/TicketSettingForm';
+import { getMyExpoInfo } from '../../../api/service/expo-admin/setting/ExpoInfoService';
 
 function Setting() {
+  const { expoId } = useParams();
+  const [status, setStatus] = useState('');
+
+  const getStatusText = (status) => {
+    const statusMap = {
+      'PENDING_APPROVAL': '승인 대기',
+      'PENDING_PAYMENT': '결제 대기',
+      'PENDING_PUBLISH': '게시 대기',
+      'PUBLISHED': '게시 중',
+      'PUBLISH_ENDED': '게시 종료',
+      'CANCELLED': '취소됨',
+      'REJECTED': '거절됨',
+      'COMPLETED': '완료됨'
+    };
+    return statusMap[status] || status;
+  };
+
+  useEffect(() => {
+    const fetchExpoStatus = async () => {
+      if (!expoId) return;
+      try {
+        const data = await getMyExpoInfo(expoId);
+        setStatus(data.status);
+      } catch (error) {
+        console.error('Failed to fetch expo status:', error);
+      }
+    };
+    
+    fetchExpoStatus();
+  }, [expoId]);
   return (
     <div className={styles.settingContainer}>
 
       <div className={styles.section}>
-        <h4 className={styles.sectionTitle}>내 박람회 정보</h4>
+        <h3 className={styles.sectionTitle}>
+          내 박람회 정보
+          <span className={`${styles.badge} ${styles[`badge${status}`]}`}>
+            {getStatusText(status)}
+          </span>
+        </h3>
         <ExpoSettingForm/>
       </div>
 

--- a/src/expo-admin/pages/setting/Setting.module.css
+++ b/src/expo-admin/pages/setting/Setting.module.css
@@ -37,3 +37,45 @@
   width: 100%; 
   max-width: 1550px; 
 }
+
+/* --- Status Badge --- */
+.badge {
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: bold;
+  color: #fff;
+  margin-left: 12px;
+}
+
+.badgePENDING_APPROVAL {
+  background-color: #f0ad4e; /* 승인대기 - 주황 */
+}
+
+.badgePENDING_PAYMENT {
+  background-color: #d9534f; /* 결제대기 - 빨강 */
+}
+
+.badgePENDING_PUBLISH {
+  background-color: #5bc0de; /* 게시대기 - 하늘 */
+}
+
+.badgePUBLISHED {
+  background-color: #5cb85c; /* 게시중 - 초록 */
+}
+
+.badgePUBLISH_ENDED {
+  background-color: #777; /* 게시종료 - 회색 */
+}
+
+.badgeCANCELLED {
+  background-color: #666; /* 취소됨 - 짙은 회색 */
+}
+
+.badgeREJECTED {
+  background-color: #d9534f; /* 거절됨 - 빨강 */
+}
+
+.badgeCOMPLETED {
+  background-color: #337ab7; /* 완료됨 - 파랑 */
+}


### PR DESCRIPTION
**박람회 상태 표시**

기존 폼 내부가 아니라, Setting.jsx에서 "내 박람회 정보" 타이틀 옆에 인라인 배지로 표시되어 페이지 상단에서 바로 확인 가능.

**카테고리 표시**

카테고리 ID 대신 API(getCategories)를 통해 가져온 실제 카테고리 이름을 표시.

카테고리가 없으면 "카테고리 없음"으로 안내.

여러 카테고리가 있을 경우 쉼표로 구분해 한 줄로 표시.


부스 상세에서 이미지 표출

토스트 관련 오류 수정