### PR TITLE
feat: 정산 시스템 UI 완전 구현 및 플랫폼 관리자 기능 개선

### DIFF
--- a/src/mypage/components/expoApplicationDetail/ExpoApplicationDetail.jsx
+++ b/src/mypage/components/expoApplicationDetail/ExpoApplicationDetail.jsx
@@ -92,6 +92,12 @@ function ExpoApplicationDetail({
           {(status === '게시종료' || status === '게시 종료') && (
             <button className={`${styles.button} ${styles.receiptButton}`} onClick={onSettlementReceiptClick}>정산 신청</button>
           )}
+          {(status === '정산요청' || status === '정산 요청') && (
+            <button className={`${styles.button} ${styles.receiptButton}`} onClick={onSettlementReceiptClick}>정산 정보 조회</button>
+          )}
+          {status === '종료됨' && (
+            <button className={`${styles.button} ${styles.receiptButton}`} onClick={onSettlementReceiptClick}>정산 완료 정보 조회</button>
+          )}
           {(status === '게시대기' || status === '게시 대기' || status === '게시중' || status === '게시 중') && (
             <button className={`${styles.button} ${styles.receiptButton}`} onClick={onRefundButtonClick}>환불 신청</button>
           )}

--- a/src/mypage/components/paymentDetailModal/SettlementReceiptModal.jsx
+++ b/src/mypage/components/paymentDetailModal/SettlementReceiptModal.jsx
@@ -4,7 +4,7 @@ import { requestExpoSettlement } from '../../../api/service/user/memberApi';
 
 const bankOptions = ['토스뱅크', '카카오뱅크', '신한은행', '국민은행', '우리은행', '하나은행', '기업은행', 'NH농협은행'];
 
-const SettlementReceiptModal = ({ receiptData, onClose, expoId }) => {
+const SettlementReceiptModal = ({ receiptData, onClose, expoId, readOnly = false, bankInfo = null }) => {
   if (!receiptData) return null;
 
   const [settlementForm, setSettlementForm] = useState({
@@ -43,98 +43,124 @@ const SettlementReceiptModal = ({ receiptData, onClose, expoId }) => {
     <div className={styles.modalOverlay}>
       <div className={styles.modalContent}>
         <h2 className={styles.title}>정산 내역 확인</h2>
-        <div className={styles.receiptContainer}>
-          <div className={styles.infoGrid}>
-            <div className={styles.infoItem}>
-              <span className={styles.label}>박람회명</span>
-              <span className={styles.value}>{receiptData.expoTitle}</span>
-            </div>
-            <div className={styles.infoItem}>
-              <span className={styles.label}>정산 요청일</span>
-              <span className={styles.value}>{new Date(receiptData.settlementRequestDate).toLocaleDateString('ko-KR')}</span>
-            </div>
-          </div>
-
-          {receiptData.ticketSales && receiptData.ticketSales.length > 0 && (
-            <div className={styles.ticketSalesSection}>
-              <h3>티켓 판매 내역</h3>
-              <div className={styles.ticketSalesHeader}>
-                <span>티켓명</span>
-                <span>판매 개수</span>
-                <span>총 판매 금액</span>
+        <div className={styles.contentLayout}>
+          {/* 왼쪽 섹션: 박람회 정보 + 티켓 판매 내역 */}
+          <div className={styles.leftSection}>
+            <div className={styles.infoGrid}>
+              <div className={styles.infoItem}>
+                <span className={styles.label}>박람회명</span>
+                <span className={styles.value}>{receiptData.expoTitle}</span>
               </div>
-              {receiptData.ticketSales.map((ticket, index) => (
-                <div key={index} className={styles.ticketSalesItem}>
-                  <span>{ticket.ticketName}</span>
-                  <span>{ticket.soldCount}개</span>
-                  <span>{ticket.totalSales.toLocaleString()}원</span>
+              <div className={styles.infoItem}>
+                <span className={styles.label}>정산 요청일</span>
+                <span className={styles.value}>{new Date(receiptData.settlementRequestDate).toLocaleDateString('ko-KR')}</span>
+              </div>
+            </div>
+
+            {receiptData.ticketSales && receiptData.ticketSales.length > 0 && (
+              <div className={styles.ticketSalesSection}>
+                <h3>티켓 판매 내역</h3>
+                <div className={styles.ticketSalesHeader}>
+                  <span>티켓명</span>
+                  <span>판매 개수</span>
+                  <span>총 판매 금액</span>
                 </div>
-              ))}
-            </div>
-          )}
-
-          <div className={styles.summarySection}>
-            <div className={styles.summaryItem}>
-              <span className={styles.label}>총 판매 금액</span>
-              <span className={styles.value}>{receiptData.totalRevenue.toLocaleString()}원</span>
-            </div>
-            <div className={styles.summaryItem}>
-              <span className={styles.label}>플랫폼 수수료 ({receiptData.commissionRate}%)</span>
-              <span className={styles.value}>-{receiptData.fee.toLocaleString()}원</span>
-            </div>
-            <div className={`${styles.summaryItem} ${styles.netProfit}`}>
-              <span className={styles.label}>순수익</span>
-              <span className={styles.value}>{receiptData.finalSettlementAmount.toLocaleString()}원</span>
-            </div>
-          </div>
-        </div>
-
-        {/* 은행계좌 입력 섹션 */}
-        <div className={styles.settlementFormSection}>
-          <h3 className={styles.formTitle}>정산 신청 정보</h3>
-          <div className={styles.formGrid}>
-            <div className={styles.formGroup}>
-              <label className={styles.formLabel}>은행</label>
-              <select
-                name="bankName"
-                className={styles.formSelect}
-                value={settlementForm.bankName}
-                onChange={handleFormChange}
-                disabled={loading}
-              >
-                <option value="">은행을 선택해주세요</option>
-                {bankOptions.map((bank) => (
-                  <option key={bank} value={bank}>
-                    {bank}
-                  </option>
+                {receiptData.ticketSales.map((ticket, index) => (
+                  <div key={index} className={styles.ticketSalesItem}>
+                    <span>{ticket.ticketName}</span>
+                    <span>{ticket.soldCount}개</span>
+                    <span>{ticket.totalSales.toLocaleString()}원</span>
+                  </div>
                 ))}
-              </select>
+              </div>
+            )}
+          </div>
+
+          {/* 오른쪽 섹션: 금액 정보 + 정산 신청 정보 */}
+          <div className={styles.rightSection}>
+            <div className={styles.summarySection}>
+              <div className={styles.summaryItem}>
+                <span className={styles.label}>총 판매 금액</span>
+                <span className={styles.value}>{receiptData.totalRevenue.toLocaleString()}원</span>
+              </div>
+              <div className={styles.summaryItem}>
+                <span className={styles.label}>플랫폼 수수료 ({receiptData.commissionRate}%)</span>
+                <span className={styles.value}>-{receiptData.fee.toLocaleString()}원</span>
+              </div>
+              <div className={styles.divider}></div>
+              <div className={`${styles.summaryItem} ${styles.netProfit}`}>
+                <span className={styles.label}>순수익</span>
+                <span className={styles.value}>{receiptData.finalSettlementAmount.toLocaleString()}원</span>
+              </div>
             </div>
 
-            <div className={styles.formGroup}>
-              <label className={styles.formLabel}>계좌번호</label>
-              <input
-                type="text"
-                name="bankAccount"
-                className={styles.formInput}
-                value={settlementForm.bankAccount}
-                onChange={handleFormChange}
-                placeholder="계좌번호를 입력해주세요"
-                disabled={loading}
-              />
-            </div>
+            {/* 은행계좌 입력/조회 섹션 */}
+            <div className={styles.settlementFormSection}>
+              <h3 className={styles.formTitle}>정산 신청 정보</h3>
+              {readOnly && bankInfo ? (
+                // 조회 모드: 은행정보 표시
+                <div className={styles.infoGrid}>
+                  <div className={styles.infoItem}>
+                    <span className={styles.label}>은행</span>
+                    <span className={styles.value}>{bankInfo.bankName || '정보 없음'}</span>
+                  </div>
+                  <div className={styles.infoItem}>
+                    <span className={styles.label}>계좌번호</span>
+                    <span className={styles.value}>{bankInfo.bankAccount || '정보 없음'}</span>
+                  </div>
+                  <div className={styles.infoItem}>
+                    <span className={styles.label}>예금주명</span>
+                    <span className={styles.value}>{bankInfo.receiverName || '정보 없음'}</span>
+                  </div>
+                </div>
+              ) : (
+                // 입력 모드: 폼 표시
+                <div className={styles.formGrid}>
+                  <div className={styles.formGroup}>
+                    <label className={styles.formLabel}>은행</label>
+                    <select
+                      name="bankName"
+                      className={styles.formSelect}
+                      value={settlementForm.bankName}
+                      onChange={handleFormChange}
+                      disabled={loading}
+                    >
+                      <option value="">은행을 선택해주세요</option>
+                      {bankOptions.map((bank) => (
+                        <option key={bank} value={bank}>
+                          {bank}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
 
-            <div className={styles.formGroup}>
-              <label className={styles.formLabel}>예금주명</label>
-              <input
-                type="text"
-                name="receiverName"
-                className={styles.formInput}
-                value={settlementForm.receiverName}
-                onChange={handleFormChange}
-                placeholder="예금주명을 입력해주세요"
-                disabled={loading}
-              />
+                  <div className={styles.formGroup}>
+                    <label className={styles.formLabel}>계좌번호</label>
+                    <input
+                      type="text"
+                      name="bankAccount"
+                      className={styles.formInput}
+                      value={settlementForm.bankAccount}
+                      onChange={handleFormChange}
+                      placeholder="계좌번호를 입력해주세요"
+                      disabled={loading}
+                    />
+                  </div>
+
+                  <div className={styles.formGroup}>
+                    <label className={styles.formLabel}>예금주명</label>
+                    <input
+                      type="text"
+                      name="receiverName"
+                      className={styles.formInput}
+                      value={settlementForm.receiverName}
+                      onChange={handleFormChange}
+                      placeholder="예금주명을 입력해주세요"
+                      disabled={loading}
+                    />
+                  </div>
+                </div>
+              )}
             </div>
           </div>
         </div>
@@ -143,13 +169,15 @@ const SettlementReceiptModal = ({ receiptData, onClose, expoId }) => {
           <button className={styles.closeButton} onClick={onClose} disabled={loading}>
             닫기
           </button>
-          <button 
-            className={styles.submitButton} 
-            onClick={handleSubmitSettlement}
-            disabled={loading}
-          >
-            {loading ? '신청 중...' : '정산 신청'}
-          </button>
+          {!readOnly && (
+            <button 
+              className={styles.submitButton} 
+              onClick={handleSubmitSettlement}
+              disabled={loading}
+            >
+              {loading ? '신청 중...' : '정산 신청'}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/mypage/components/paymentDetailModal/SettlementReceiptModal.module.css
+++ b/src/mypage/components/paymentDetailModal/SettlementReceiptModal.module.css
@@ -16,7 +16,7 @@
   padding: 30px;
   border-radius: 12px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
-  width: 500px;
+  width: 900px;
   max-width: 90%;
 }
 
@@ -26,6 +26,21 @@
   margin-bottom: 25px;
   text-align: center;
   color: #333;
+}
+
+/* 2컴럼 레이아웃 */
+.contentLayout {
+  display: flex;
+  gap: 48px;
+  margin-bottom: 25px;
+}
+
+.leftSection {
+  flex: 1;
+}
+
+.rightSection {
+  flex: 1;
 }
 
 .receiptContainer {
@@ -111,9 +126,13 @@
 }
 
 .summarySection {
-  margin-top: 20px;
-  border-top: 1px solid #eee;
-  padding-top: 20px;
+  margin-bottom: 24px;
+}
+
+.divider {
+  height: 1px;
+  background-color: #ddd;
+  margin: 16px 0;
 }
 
 .summaryItem {
@@ -125,7 +144,6 @@
 
 .summaryItem:last-child {
   font-weight: bold;
-  border-top: 2px solid #333;
   padding-top: 15px;
   margin-top: 15px;
 }
@@ -150,8 +168,8 @@
 
 /* 정산 신청 폼 스타일 */
 .settlementFormSection {
-  margin-top: 25px;
-  padding-top: 25px;
+  margin-top: 24px;
+  padding-top: 24px;
   border-top: 2px solid #eee;
 }
 

--- a/src/mypage/pages/expoStatusDetail/ExpoStatusDetail.jsx
+++ b/src/mypage/pages/expoStatusDetail/ExpoStatusDetail.jsx
@@ -265,6 +265,10 @@ const ExpoStatusDetail = () => {
         finalSettlementAmount: response.data.netProfit,
         ticketSales: response.data.ticketSales,
         commissionRate: response.data.commissionRate,
+        // 은행정보 추가
+        bankName: response.data.bankName,
+        bankAccount: response.data.bankAccount,
+        receiverName: response.data.receiverName,
       };
       setSettlementReceiptData(transformedReceiptData);
       setShowSettlementReceiptModal(true);
@@ -413,6 +417,12 @@ const ExpoStatusDetail = () => {
           receiptData={settlementReceiptData}
           onClose={handleCloseSettlementReceiptModal}
           expoId={id}
+          readOnly={expoData?.status === '정산요청' || expoData?.status === '정산 요청' || expoData?.status === 'SETTLEMENT_REQUESTED' || expoData?.status === '종료됨'}
+          bankInfo={expoData?.status === '정산요청' || expoData?.status === '정산 요청' || expoData?.status === 'SETTLEMENT_REQUESTED' || expoData?.status === '종료됨' ? {
+            bankName: settlementReceiptData?.bankName,
+            bankAccount: settlementReceiptData?.bankAccount, 
+            receiverName: settlementReceiptData?.receiverName
+          } : null}
         />
       )}
 

--- a/src/platform-admin/components/expoApplicationForm/ExpoApplicationForm.jsx
+++ b/src/platform-admin/components/expoApplicationForm/ExpoApplicationForm.jsx
@@ -26,6 +26,15 @@ function ExpoApplicationForm({ expoData }) {
 
         <div className={styles.formGrid}>
           <div className={`${styles.formGroup} ${styles.full}`}>
+            <label className={styles.label}>카테고리</label>
+            <div className={styles.badgeRow}>
+              <div className={styles.badge}>
+                {form.category || '카테고리 없음'}
+              </div>
+            </div>
+          </div>
+
+          <div className={`${styles.formGroup} ${styles.full}`}>
             <label className={styles.label}>박람회 이름</label>
             <input
               className={styles.inputField}
@@ -132,14 +141,6 @@ function ExpoApplicationForm({ expoData }) {
             </div>
           </div>
 
-          <div className={`${styles.formGroup} ${styles.full}`}>
-            <label className={styles.label}>카테고리</label>
-            <div className={styles.badgeRow}>
-              <div className={styles.badge}>
-                {form.category || '카테고리 없음'}
-              </div>
-            </div>
-          </div>
         </div>
       </div>
 

--- a/src/platform-admin/components/settlementDetailModal/SettlementDetailModal.jsx
+++ b/src/platform-admin/components/settlementDetailModal/SettlementDetailModal.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import styles from './SettlementDetailModal.module.css';
 import { fetchSettlementDetail, approveSettlement } from '../../../api/service/platform-admin/expo/ExpoService';
 
-function SettlementDetailModal({ isOpen, onClose, expoId, onSettlementApprove }) {
+function SettlementDetailModal({ isOpen, onClose, expoId, readOnly = false, onSettlementApprove }) {
   const [settlementData, setSettlementData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [approving, setApproving] = useState(false);
@@ -71,93 +71,105 @@ function SettlementDetailModal({ isOpen, onClose, expoId, onSettlementApprove })
         <h2 className={styles.title}>정산 내역</h2>
 
         {settlementData ? (
-          <>
-            <div className={styles.infoBox}>
-              <div className={styles.row}>
-                <span className={styles.label}>박람회명</span>
-                <span className={styles.value}>{settlementData.expoTitle}</span>
-              </div>
-              <div className={styles.row}>
-                <span className={styles.label}>게시 기간</span>
-                <span className={styles.value}>
-                  {settlementData.displayStartDate} ~ {settlementData.displayEndDate}
-                </span>
-              </div>
-              <div className={styles.row}>
-                <span className={styles.label}>상태</span>
-                <span className={styles.value}>{settlementData.status}</span>
-              </div>
-            </div>
-
-            <div className={styles.feeBox}>
-              <div className={styles.row}>
-                <span className={styles.label}>총 매출</span>
-                <span className={styles.amount}>{settlementData.totalRevenue?.toLocaleString()}원</span>
-              </div>
-              <div className={styles.row}>
-                <span className={styles.label}>수수료율</span>
-                <span className={styles.amount}>{settlementData.commissionRate}%</span>
-              </div>
-              <div className={styles.row}>
-                <span className={styles.label}>수수료 금액</span>
-                <span className={styles.amount}>{settlementData.commissionAmount?.toLocaleString()}원</span>
-              </div>
-              <div className={`${styles.row} ${styles.totalRow}`}>
-                <span className={styles.totalLabel}>순수익</span>
-                <span className={styles.totalAmount}>{settlementData.netProfit?.toLocaleString()}원</span>
-              </div>
-            </div>
-
-            {/* 정산 완료 상태일 때 추가 정보 표시 */}
-            {settlementData.status === 'COMPLETED' && (
-              <div className={styles.completionBox}>
-                <h3 className={styles.completionTitle}>정산 완료 정보</h3>
-                <div className={styles.row}>
-                  <span className={styles.label}>정산 계좌 예금주</span>
-                  <span className={styles.value}>{settlementData.receiverName || '정보 없음'}</span>
-                </div>
-                <div className={styles.row}>
-                  <span className={styles.label}>은행명</span>
-                  <span className={styles.value}>{settlementData.bankName || '정보 없음'}</span>
-                </div>
-                <div className={styles.row}>
-                  <span className={styles.label}>계좌번호</span>
-                  <span className={styles.value}>{settlementData.bankAccount || '정보 없음'}</span>
-                </div>
-                <div className={styles.row}>
-                  <span className={styles.label}>정산 승인 시점</span>
-                  <span className={styles.value}>{settlementData.settlementAt || '정보 없음'}</span>
-                </div>
-                <div className={styles.row}>
-                  <span className={styles.label}>정산 처리 담당자</span>
-                  <span className={styles.value}>{settlementData.adminName || '정보 없음'}</span>
-                </div>
-              </div>
-            )}
-
-            {settlementData.ticketSales && settlementData.ticketSales.length > 0 && (
+          <div className={styles.contentLayout}>
+            {/* 왼쪽 섹션: 박람회 정보 + 티켓 판매 내역 */}
+            <div className={styles.leftSection}>
               <div className={styles.infoBox}>
-                <h3>티켓 판매 내역</h3>
-                {settlementData.ticketSales.map((ticket, index) => (
-                  <div key={index} className={styles.row}>
-                    <span className={styles.label}>
-                      {ticket.ticketName} ({ticket.ticketPrice?.toLocaleString()}원)
-                    </span>
-                    <span className={styles.value}>
-                      {ticket.soldCount}매 판매 (총 {ticket.totalSales?.toLocaleString()}원)
-                    </span>
-                  </div>
-                ))}
+                <div className={styles.row}>
+                  <span className={styles.label}>박람회명</span>
+                  <span className={styles.value}>{settlementData.expoTitle}</span>
+                </div>
+                <div className={styles.row}>
+                  <span className={styles.label}>게시 기간</span>
+                  <span className={styles.value}>
+                    {settlementData.displayStartDate} ~ {settlementData.displayEndDate}
+                  </span>
+                </div>
+                <div className={styles.row}>
+                  <span className={styles.label}>상태</span>
+                  <span className={styles.value}>{settlementData.status}</span>
+                </div>
               </div>
-            )}
-          </>
+
+              {settlementData.ticketSales && settlementData.ticketSales.length > 0 && (
+                <div className={styles.infoBox}>
+                  <h3>티켓 판매 내역</h3>
+                  {settlementData.ticketSales.map((ticket, index) => (
+                    <div key={index} className={styles.row}>
+                      <span className={styles.label}>
+                        {ticket.ticketName} ({ticket.ticketPrice?.toLocaleString()}원)
+                      </span>
+                      <span className={styles.value}>
+                        {ticket.soldCount}매 판매 (총 {ticket.totalSales?.toLocaleString()}원)
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* 오른쪽 섹션: 금액 정보 + 은행 정보 */}
+            <div className={styles.rightSection}>
+              <div className={styles.feeBox}>
+                <div className={styles.row}>
+                  <span className={styles.label}>총 매출</span>
+                  <span className={styles.amount}>{settlementData.totalRevenue?.toLocaleString()}원</span>
+                </div>
+                <div className={styles.row}>
+                  <span className={styles.label}>수수료율</span>
+                  <span className={styles.amount}>{settlementData.commissionRate}%</span>
+                </div>
+                <div className={styles.row}>
+                  <span className={styles.label}>수수료 금액</span>
+                  <span className={styles.amount}>{settlementData.commissionAmount?.toLocaleString()}원</span>
+                </div>
+                <div className={`${styles.row} ${styles.totalRow}`}>
+                  <span className={styles.totalLabel}>순수익</span>
+                  <span className={styles.totalAmount}>{settlementData.netProfit?.toLocaleString()}원</span>
+                </div>
+              </div>
+
+              {/* 정산 요청 또는 완료 상태일 때 은행 정보 표시 */}
+              {(settlementData.status === 'SETTLEMENT_REQUESTED' || settlementData.status === 'COMPLETED') && (
+                <div className={styles.completionBox}>
+                  <h3 className={styles.completionTitle}>
+                    {settlementData.status === 'COMPLETED' ? '정산 완료 정보' : '정산 신청 정보'}
+                  </h3>
+                  <div className={styles.row}>
+                    <span className={styles.label}>정산 계좌 예금주</span>
+                    <span className={styles.value}>{settlementData.receiverName || '정보 없음'}</span>
+                  </div>
+                  <div className={styles.row}>
+                    <span className={styles.label}>은행명</span>
+                    <span className={styles.value}>{settlementData.bankName || '정보 없음'}</span>
+                  </div>
+                  <div className={styles.row}>
+                    <span className={styles.label}>계좌번호</span>
+                    <span className={styles.value}>{settlementData.bankAccount || '정보 없음'}</span>
+                  </div>
+                  {settlementData.status === 'COMPLETED' && (
+                    <>
+                      <div className={styles.row}>
+                        <span className={styles.label}>정산 승인 시점</span>
+                        <span className={styles.value}>{settlementData.settlementAt || '정보 없음'}</span>
+                      </div>
+                      <div className={styles.row}>
+                        <span className={styles.label}>정산 처리 담당자</span>
+                        <span className={styles.value}>{settlementData.adminName || '정보 없음'}</span>
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
         ) : (
           <div style={{ padding: '20px', textAlign: 'center' }}>정산 내역을 불러올 수 없습니다.</div>
         )}
 
         <div className={styles.actionBox}>
           <button className={styles.cancelBtn} onClick={onClose}>닫기</button>
-          {settlementData?.status !== 'COMPLETED' && (
+          {!readOnly && settlementData?.status !== 'COMPLETED' && (
             <button 
               className={styles.approveBtn} 
               onClick={handleSettlementApprove}

--- a/src/platform-admin/components/settlementDetailModal/SettlementDetailModal.module.css
+++ b/src/platform-admin/components/settlementDetailModal/SettlementDetailModal.module.css
@@ -13,7 +13,7 @@
 
 .modal {
   background: #fff;
-  width: 480px;
+  width: 900px;
   padding: 28px 24px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
   font-family: 'Pretendard', sans-serif;
@@ -131,4 +131,19 @@
   color: #155724;
   margin-bottom: 12px;
   text-align: center;
+}
+
+/* 2컬럼 레이아웃 */
+.contentLayout {
+  display: flex;
+  gap: 48px;
+  margin-bottom: 25px;
+}
+
+.leftSection {
+  flex: 1;
+}
+
+.rightSection {
+  flex: 1;
 }

--- a/src/platform-admin/pages/expoCurrentDetail/ExpoCurrentDetail.jsx
+++ b/src/platform-admin/pages/expoCurrentDetail/ExpoCurrentDetail.jsx
@@ -12,6 +12,7 @@ import { fetchExpoDetail, approveCancellation, approveSettlement, fetchPaymentIn
 const statusClassMap = {
   PENDING_CANCEL: '취소_대기',
   PENDING_PAYMENT: '결제_대기',
+  PENDING_PUBLISH: '게시_대기',
   PUBLISHED: '게시중',
   PUBLISH_ENDED: '게시_종료',
   SETTLEMENT_REQUESTED: '정산_요청',
@@ -22,6 +23,7 @@ const statusClassMap = {
 const statusTextMap = {
   취소_대기: '취소 대기',
   결제_대기: '승인 완료',
+  게시_대기: '게시 대기',
   게시중: '게시 중',
   게시_종료: '게시 종료',
   정산_요청: '정산 요청',
@@ -164,7 +166,13 @@ function ExpoCurrentDetail() {
     buttonGroup = (
       <div className={styles.buttonGroup}>
         <button
-          className={styles.rejectBtn}
+          className={styles.infoBtn}
+          onClick={handlePaymentDetailOpen}
+        >
+          결제 정보
+        </button>
+        <button
+          className={styles.approveBtn}
           onClick={() => setShowSettlementDetail(true)}
         >
           정산 정보 조회
@@ -200,8 +208,22 @@ function ExpoCurrentDetail() {
       </div>
     );
   } else if (expo?.status === 'PUBLISH_ENDED') {
-    // 게시 종료 - 버튼 없음 (박람회 관리자 권한으로 처리)
-    buttonGroup = null;
+    buttonGroup = (
+      <div className={styles.buttonGroup}>
+        <button
+          className={styles.infoBtn}
+          onClick={handlePaymentDetailOpen}
+        >
+          결제 정보
+        </button>
+        <button
+          className={styles.approveBtn}
+          onClick={() => setShowSettlementDetail(true)}
+        >
+          정산 정보 조회
+        </button>
+      </div>
+    );
   }
 
   if (loading) {
@@ -243,6 +265,7 @@ function ExpoCurrentDetail() {
         isOpen={showSettlementDetail}
         onClose={() => setShowSettlementDetail(false)}
         expoId={id}
+        readOnly={expo?.status === 'PUBLISH_ENDED'}
         onSettlementApprove={async () => {
           await loadExpoDetail(); // 상태 업데이트
         }}

--- a/src/platform-admin/pages/expoCurrentDetail/ExpoCurrentDetail.module.css
+++ b/src/platform-admin/pages/expoCurrentDetail/ExpoCurrentDetail.module.css
@@ -87,6 +87,10 @@
   background-color: #f0ad4e;
 }
 
+.게시_대기 {
+  background-color: #f0ad4e;
+}
+
 .게시_종료 {
   background-color: #777;
 }


### PR DESCRIPTION
## 주요 변경사항
- 플랫폼 관리자 정산 승인 모달 2컬럼 레이아웃 적용
- 박람회 관리자 COMPLETED 상태 정산 완료 정보 조회 버튼 추가
- SettlementReceiptModal readOnly 모드 COMPLETED 상태 지원
- 정산 요청/완료 상태별 적절한 모달 동작 구현

## UI/UX 개선
- 정산 승인 모달 은행정보 표시 조건 수정 (SETTLEMENT_REQUESTED 포함)
- 2컬럼 레이아웃으로 정보 가독성 향상
- 상태별 버튼 라벨 명확화 ("정산 정보 조회" vs "정산 완료 정보 조회")