### PR TITLE
refactor: 배너 2차 수정 사항 반영

### DIFF
--- a/src/api/service/platform-admin/banner/BannerService.jsx
+++ b/src/api/service/platform-admin/banner/BannerService.jsx
@@ -24,39 +24,43 @@ export const getCurrentBanner = async () => {
   return res.data;
 };
 
-export const getPaymentInfo = async ( bannerId ) => {
+export const getPaymentInfo = async (bannerId) => {
   const res = await instance.get(`/platform/ads/${bannerId}/payment-check`);
   return res.data;
 };
 
 export const approveBanner = async (bannerId, paymentInfo) => {
-    const res = await instance.post(`/platform/ads/${bannerId}/approve`, {paymentInfo});
+  const res = await instance.post(`/platform/ads/${bannerId}/approve`, { paymentInfo });
 }
 
 export const fetchCancelInfo = async (bannerId) => {
-    const res = await instance.get(`/platform/ads/${bannerId}/cancel-check`);
-    return res.data;
+  const res = await instance.get(`/platform/ads/${bannerId}/cancel-check`);
+  return res.data;
+}
+
+export const denyCancelBanner = async (bannerId) => {
+  const res = await instance.patch(`/platform/ads/${bannerId}/cancel/deny`);
 }
 
 export const cancelBanner = async (bannerId, cancelInfo) => {
-    const res = await instance.post(`/platform/ads/${bannerId}/cancel`, {cancelInfo});
+  const res = await instance.post(`/platform/ads/${bannerId}/cancel`, { cancelInfo });
 }
- 
+
 export const fetchRejectInfo = async (bannerId) => {
-    const res = await instance.get(`/platform/ads/${bannerId}/reject`);
-    return res.data;
+  const res = await instance.get(`/platform/ads/${bannerId}/reject`);
+  return res.data;
 }
 
 export const rejectBanner = async ({ id, reason }) => {
-    const res = await instance.post(`/platform/ads/${id}/reject`, {reason});
+  const res = await instance.post(`/platform/ads/${id}/reject`, { reason });
 }
 
 export const fetchPaymentDetail = async (bannerId) => {
-    const res = await instance.get(`/platform/ads/${bannerId}/payment-history`);
-    return res.data;
+  const res = await instance.get(`/platform/ads/${bannerId}/payment-history`);
+  return res.data;
 }
 
 export const fetchCancelDetail = async (bannerId) => {
-    const res = await instance.get(`/platform/ads/${bannerId}/cancel-history`);
-    return res.data;
+  const res = await instance.get(`/platform/ads/${bannerId}/cancel-history`);
+  return res.data;
 }

--- a/src/mainpage/components/banners/MainBanner.jsx
+++ b/src/mainpage/components/banners/MainBanner.jsx
@@ -12,7 +12,7 @@ export default function MainBanner({ banners }) {
     }, 4000); // 4초마다 전환
 
     return () => clearInterval(interval);
-  }, []);
+  }, [banners]);
 
   return (
     <div className={styles.banner}>

--- a/src/platform-admin/components/bannerCancelSummaryModal/AdCancelSummaryModal.jsx
+++ b/src/platform-admin/components/bannerCancelSummaryModal/AdCancelSummaryModal.jsx
@@ -57,7 +57,7 @@ function SettlementSummaryModal({ isOpen, onClose, onSubmit, cancelForm }) {
         {/* 버튼 */}
         <div className={styles.actionBox}>
           <button className={styles.cancelBtn} onClick={onClose}>취소</button>
-          <button className={styles.submitBtn} onClick={onSubmit}>정산 요청</button>
+          <button className={styles.submitBtn} onClick={onSubmit}>환불 승인</button>
         </div>
       </div>
     </div>

--- a/src/platform-admin/components/paymentDetailModal/PaymentDetailModal.jsx
+++ b/src/platform-admin/components/paymentDetailModal/PaymentDetailModal.jsx
@@ -2,7 +2,8 @@ import styles from './PaymentDetailModal.module.css';
 
 function PaymentDetailModal({ isOpen, onClose, paymentDetail }) {
   if (!isOpen) return null;
-  const paymentType = paymentDetail.paymentType;
+
+  const paymentType = paymentDetail?.paymentType;
 
   // 결제수단 한글 매핑
   const typeLabelMap = {
@@ -11,11 +12,12 @@ function PaymentDetailModal({ isOpen, onClose, paymentDetail }) {
     TRANSFER: '계좌이체',
     FOREIGN_PAY: '해외결제',
   };
-  const paymentTypeLabel = typeLabelMap[paymentType] || paymentType || '-';
-  // 계좌/카드 명칭 분기
+  
+  // 조건에 따라 동적으로 값 설정
   const isTransfer = paymentType === 'TRANSFER';
-  const companyLabel = isTransfer ? '은행' : '카드사';
-  const accountLabel = isTransfer ? '은행 계좌번호' : '카드 번호';
+  const paymentTypeLabel = paymentType ? typeLabelMap[paymentType] : '-';
+  const companyLabel = paymentType ? (isTransfer ? '은행' : '카드사') : '-';
+  const accountLabel = paymentType ? (isTransfer ? '은행 계좌번호' : '카드 번호') : '-';
 
   return (
     <div className={styles.modalOverlay}>
@@ -43,15 +45,15 @@ function PaymentDetailModal({ isOpen, onClose, paymentDetail }) {
         <div className={styles.infoBox}>
           <div className={styles.row}>
             <span className={styles.label}>결제 수단</span>
-            <span className={styles.value}>{typeLabelMap[paymentType]}</span>
+            <span className={styles.value}>{paymentTypeLabel}</span>
           </div>
           <div className={styles.row}>
             <span className={styles.label}>{companyLabel}</span>
-            <span className={styles.value}>{paymentDetail?.paymentCompanyName}</span>
+            <span className={styles.value}>{paymentType ? paymentDetail?.paymentCompanyName : '-'}</span>
           </div>
           <div className={styles.row}>
             <span className={styles.label}>{accountLabel}</span>
-            <span className={styles.value}>{paymentDetail?.paymentAccountInfo}</span>
+            <span className={styles.value}>{paymentType ? paymentDetail?.paymentAccountInfo : '-'}</span>
           </div>
         </div>
 

--- a/src/platform-admin/components/paymentSummaryModal/PaymentSummaryModal.jsx
+++ b/src/platform-admin/components/paymentSummaryModal/PaymentSummaryModal.jsx
@@ -63,6 +63,7 @@ function PaymentSummaryModal({ isOpen, onClose, onSubmit }) {
   const requesterName = paymentInfo?.requesterName ?? '-';
   const startAt = paymentInfo?.startAt ?? '-';
   const endAt = paymentInfo?.endAt ?? '-';
+  const totalDays = paymentInfo?.totalDays ?? '-';
   const totalPayment = paymentInfo?.totalPayment ?? 0;
 
   return (
@@ -94,6 +95,11 @@ function PaymentSummaryModal({ isOpen, onClose, onSubmit }) {
         </div>
 
         <div className={styles.feeBox}>
+          <div className={styles.row}>
+            <span className={styles.label}>이용 일수</span>
+            <span className={styles.amount}>{totalDays}일</span>
+          </div>
+
           {feeItems.map(([label, amount]) => (
             <div className={styles.row} key={label}>
               <span className={styles.label}>{label}</span>

--- a/src/platform-admin/pages/bannerCurrentDetail/BannerCurrentDetail.jsx
+++ b/src/platform-admin/pages/bannerCurrentDetail/BannerCurrentDetail.jsx
@@ -8,7 +8,7 @@ import PaymentDetailModal from '../../components/paymentDetailModal/PaymentDetai
 import AdCancelDetailModal from '../../components/bannerCancelDetailModal/AdCancelDetailModal';
 import AdCancelSummaryModal from '../../components/bannerCancelSummaryModal/AdCancelSummaryModal';
 import ToastFail from '../../../common/components/toastFail/ToastFail';
-import { fetchDetailBanner, fetchCancelInfo, cancelBanner, fetchPaymentDetail, fetchCancelDetail } from '../../../api/service/platform-admin/banner/BannerService';
+import { fetchDetailBanner, fetchCancelInfo, cancelBanner, fetchPaymentDetail, fetchCancelDetail, denyCancelBanner } from '../../../api/service/platform-admin/banner/BannerService';
 
 const statusClassMap = {
   PENDING_CANCEL: '취소_대기',
@@ -92,6 +92,19 @@ function BannerCurrentDetail() {
     setShowSettlementSummary(false);
   };
 
+  const handleCancelDeny = async () => {
+    try{
+      await denyCancelBanner(id);
+      alert("취소 거절에 성공했습니다.");
+      navigate(-1, {
+        replace: true,
+        state: { ...location.state, expoStatus: 'PUBLISHED' },
+      });
+    }catch(err){
+      console.log("취소 거부 실패 : ", err);
+    }
+  }
+
 
   useEffect(() => {
     const fetchData = async () => {
@@ -144,6 +157,7 @@ function BannerCurrentDetail() {
       <div className={styles.buttonGroup}>
         <button className={styles.approveBtn} onClick={() => setShowPaymentDetail(true)}>결제 내역</button>
         <button className={styles.approveBtn} onClick={() => setShowSettlementSummary(true)}>취소 승인</button>
+        <button className={styles.approveBtn} onClick={() => handleCancelDeny()}>취소 거절</button>
       </div>
     );
   } else if (rawStatus === 'PUBLISHED') {


### PR DESCRIPTION
### 구현 기능
* 배너 승인 영수증에 "총 일수"와 "일일 사용료" 추가
* 취소 대기 배너의 거부 api 추가
* 취소 승인 시 partial_refund 여부에 따른 분기 추가
* 기타 버튼 명칭 수정