### PR TITLE
fix: 박람회 관리자 정산 신청 플로우 수정

### DIFF
--- a/src/mypage/components/expoApplicationDetail/ExpoApplicationDetail.jsx
+++ b/src/mypage/components/expoApplicationDetail/ExpoApplicationDetail.jsx
@@ -91,7 +91,7 @@ function ExpoApplicationDetail({
             <button className={`${styles.button} ${styles.receiptButton}`} onClick={onPayButtonClick}>결제 신청</button>
           )}
           {(status === '게시종료' || status === '게시 종료') && (
-            <button className={`${styles.button} ${styles.receiptButton}`} onClick={onSettlementReceiptClick}>정산 신청</button>
+            <button className={`${styles.button} ${styles.receiptButton}`} onClick={onSettlementRequestClick}>정산 신청</button>
           )}
           {(status === '정산요청' || status === '정산 요청') && (
             <button className={`${styles.button} ${styles.receiptButton}`} onClick={onSettlementReceiptClick}>정산 정보 조회</button>

--- a/src/mypage/pages/expoStatusDetail/ExpoStatusDetail.jsx
+++ b/src/mypage/pages/expoStatusDetail/ExpoStatusDetail.jsx
@@ -281,16 +281,30 @@ const ExpoStatusDetail = () => {
     }
   };
 
-  // 정산 요청 핸들러
+  // 정산 요청 핸들러 - 모달을 통해 은행 정보 입력 후 정산 신청
   const handleSettlementRequest = async () => {
     try {
       setLoading(true);
-      await requestExpoSettlement(id);
-      alert('정산 요청이 완료되었습니다.');
-      fetchExpoDetail(); // 상태 업데이트를 위해 데이터 다시 불러오기
+      const response = await getExpoSettlementReceipt(id);
+      console.log('정산 내역 API 응답:', response.data);
+      const transformedReceiptData = {
+        expoTitle: response.data.expoTitle,
+        settlementRequestDate: response.data.issueDate,
+        totalRevenue: response.data.totalRevenue,
+        fee: response.data.commissionAmount,
+        finalSettlementAmount: response.data.netProfit,
+        ticketSales: response.data.ticketSales,
+        commissionRate: response.data.commissionRate,
+        // 은행정보는 null (정산 신청 모드)
+        bankName: null,
+        bankAccount: null,
+        receiverName: null,
+      };
+      setSettlementReceiptData(transformedReceiptData);
+      setShowSettlementReceiptModal(true);
     } catch (err) {
-      console.error('정산 요청 실패:', err);
-      alert('정산 요청에 실패했습니다.');
+      console.error('정산 내역 조회 실패:', err);
+      alert('정산 내역을 불러오는데 실패했습니다.');
     } finally {
       setLoading(false);
     }
@@ -329,6 +343,28 @@ const ExpoStatusDetail = () => {
   const handleCloseSettlementReceiptModal = () => {
     setShowSettlementReceiptModal(false);
     setSettlementReceiptData(null);
+  };
+
+  // 실제 정산 신청 처리 핸들러
+  const handleActualSettlementRequest = async (bankInfo) => {
+    try {
+      setLoading(true);
+      const settlementData = {
+        receiverName: bankInfo.receiverName,
+        bankName: bankInfo.bankName,
+        bankAccount: bankInfo.bankAccount
+      };
+      
+      await requestExpoSettlement(id, settlementData);
+      alert('정산 요청이 완료되었습니다.');
+      handleCloseSettlementReceiptModal();
+      fetchExpoDetail(); // 상태 업데이트를 위해 데이터 다시 불러오기
+    } catch (err) {
+      console.error('정산 요청 실패:', err);
+      alert('정산 요청에 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
   };
 
 
@@ -476,6 +512,7 @@ const ExpoStatusDetail = () => {
             bankAccount: settlementReceiptData?.bankAccount, 
             receiverName: settlementReceiptData?.receiverName
           } : null}
+          onSettlementRequest={handleActualSettlementRequest}
         />
       )}
 


### PR DESCRIPTION
- 게시종료 상태에서 정산 신청 버튼 핸들러 수정 (onSettlementReceiptClick → onSettlementRequestClick)
- 정산 신청 시 은행 정보 입력 모달을 먼저 표시하도록 변경
- handleActualSettlementRequest 함수 추가하여 은행 정보와 함께 정산 API 호출
- 정산 신청 모달에서 필수 bank 정보 수집 후 실제 정산 요청 처리
