### PR TITLE
refactor : 박람회 상세 티켓 목록 스타일 수정 및 유효성 검사 로직 추가

### DIFF
--- a/src/expo-admin/components/ticketSettingForm/TicketSettingForm.jsx
+++ b/src/expo-admin/components/ticketSettingForm/TicketSettingForm.jsx
@@ -1,10 +1,16 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { FaPlus , FaInfoCircle} from 'react-icons/fa';
+import { FaPlus, FaInfoCircle } from 'react-icons/fa';
 import styles from './TicketSettingForm.module.css';
 import ToastSuccess from '../../../common/components/toastSuccess/ToastSuccess';
 import ToastFail from '../../../common/components/toastFail/ToastFail';
-import { getMyExpoTickets, saveMyExpoTicket, deleteMyExpoTicket, updateMyExpoTicket } from '../../../api/service/expo-admin/setting/TicketService';
+import {
+  getMyExpoTickets,
+  saveMyExpoTicket,
+  deleteMyExpoTicket,
+  updateMyExpoTicket,
+} from '../../../api/service/expo-admin/setting/TicketService';
+import { getMyExpoInfo } from '../../../api/service/expo-admin/setting/ExpoInfoService';
 
 function TicketSettingForm() {
   const { expoId } = useParams();
@@ -17,33 +23,16 @@ function TicketSettingForm() {
   const [showFailToast, setShowFailToast] = useState(false);
   const [failMessage, setFailMessage] = useState('');
 
-  // 초기 렌더링
-  useEffect(() => {
-    const fetchTickets = async () => {
-      try {
-        const ticketData = await getMyExpoTickets(expoId);
-        setData(ticketData);
-      } catch (error) {
-        console.log(error.message);
-      }
-    };
-    fetchTickets();
-  }, [expoId]);
+  // 게시(노출) 기간 (판매 시작/종료일을 이 범위에 묶기 위함)
+  const [displayStartDate, setDisplayStartDate] = useState('');
+  const [displayEndDate, setDisplayEndDate] = useState('');
+  // 행사(운영) 기간 (사용 시작/종료일을 이 범위에 묶기 위함)
+  const [expoStartDate, setExpoStartDate] = useState('');
+  const [expoEndDate, setExpoEndDate] = useState('');
 
-  // 성공 토스트
-  const triggerSuccessToast = () => {
-    setShowSuccessToast(true);
-    setTimeout(() => setShowSuccessToast(false), 3000);
-  };
+  // expo 정보 로딩 여부 (제약 적용 시점 제어)
+  const [expoLoaded, setExpoLoaded] = useState(false);
 
-  // 실패 토스트
-  const triggerToastFail = (message) => {
-    setFailMessage(message);
-    setShowFailToast(true);
-    setTimeout(() => setShowFailToast(false), 3000);
-  };
-
-  // 티켓 초기값
   function initTicket() {
     return {
       ticketId: null,
@@ -59,7 +48,42 @@ function TicketSettingForm() {
     };
   }
 
-  // 유효성 검사 (백엔드 DTO 규칙 반영)
+  // 초기 로딩: 티켓 + 박람회 정보(게시기간/행사기간)
+  useEffect(() => {
+    const fetchAll = async () => {
+      try {
+        const [ticketData, expoInfo] = await Promise.all([
+          getMyExpoTickets(expoId),
+          getMyExpoInfo(expoId),
+        ]);
+        setData(ticketData || []);
+        setDisplayStartDate(expoInfo?.displayStartDate?.split('T')[0] || '');
+        setDisplayEndDate(expoInfo?.displayEndDate?.split('T')[0] || '');
+        setExpoStartDate(expoInfo?.startDate?.split('T')[0] || '');
+        setExpoEndDate(expoInfo?.endDate?.split('T')[0] || '');
+        setExpoLoaded(true);
+      } catch (error) {
+        console.log(error.message);
+        setExpoLoaded(true); // 실패해도 폼은 사용 가능하도록
+      }
+    };
+    if (expoId) fetchAll();
+  }, [expoId]);
+
+  // 성공 토스트
+  const triggerSuccessToast = () => {
+    setShowSuccessToast(true);
+    setTimeout(() => setShowSuccessToast(false), 3000);
+  };
+
+  // 실패 토스트
+  const triggerToastFail = (message) => {
+    setFailMessage(message);
+    setShowFailToast(true);
+    setTimeout(() => setShowFailToast(false), 3000);
+  };
+
+  // 유효성 검사 (백엔드 DTO 규칙 + 게시/행사 기간 제약 반영)
   const validateTicket = (t) => {
     if (!t.name || t.name.trim() === '') return '티켓 이름은 필수입니다.';
     if (t.name.length > 100) return '티켓 이름은 100자 이하여야 합니다.';
@@ -76,16 +100,29 @@ function TicketSettingForm() {
     if (!t.saleEndDate) return '판매 종료일은 필수입니다.';
     if (t.saleEndDate < t.saleStartDate) return '판매 종료일은 시작일과 같거나 이후여야 합니다.';
 
+    // 게시기간 내 제약 (존재할 때만 검사)
+    if (displayStartDate && t.saleStartDate < displayStartDate)
+      return '판매 시작일은 게시 시작일과 같거나 이후여야 합니다.';
+    if (displayEndDate && t.saleStartDate > displayEndDate)
+      return '판매 시작일은 게시 종료일과 같거나 이전이어야 합니다.';
+    if (displayEndDate && t.saleEndDate > displayEndDate)
+      return '판매 종료일은 게시 종료일과 같거나 이전이어야 합니다.';
+
     if (!t.useStartDate) return '사용 시작일은 필수입니다.';
     if (!t.useEndDate) return '사용 종료일은 필수입니다.';
     if (t.useEndDate < t.useStartDate) return '사용 종료일은 시작일과 같거나 이후여야 합니다.';
-
     if (t.useStartDate < t.saleStartDate) return '사용 시작일은 판매 시작일과 같거나 이후여야 합니다.';
+
+    // 행사기간 내 제약 (존재할 때만 검사)
+    if (expoStartDate && t.useStartDate < expoStartDate)
+      return '사용 시작일은 행사 시작일과 같거나 이후여야 합니다.';
+    if (expoEndDate && t.useEndDate > expoEndDate)
+      return '사용 종료일은 행사 종료일과 같거나 이전이어야 합니다.';
 
     return null;
   };
 
-  // 저장
+  // 저장(추가)
   const handleSave = async () => {
     const error = validateTicket(newTicket);
     if (error) {
@@ -93,7 +130,6 @@ function TicketSettingForm() {
       return;
     }
 
-    // 숫자 필드 변환
     const payload = {
       ...newTicket,
       price: Number(newTicket.price),
@@ -118,7 +154,6 @@ function TicketSettingForm() {
       triggerToastFail('티켓 ID가 없습니다.');
       return;
     }
-
     const confirmed = window.confirm('정말 삭제하시겠습니까?');
     if (!confirmed) return;
 
@@ -132,7 +167,7 @@ function TicketSettingForm() {
     }
   };
 
-  // 수정
+  // 수정 저장
   const handleUpdate = async () => {
     const error = validateTicket(editTicket);
     if (error) {
@@ -177,20 +212,77 @@ function TicketSettingForm() {
     setEditTicket(initTicket());
   };
 
-  // input 변경
+  // 공용 input 변경 핸들러 (게시/행사 기간 제약 즉시 보정: 기준값 존재 시에만)
   const handleChange = (e, isEdit = false) => {
     const { name, value } = e.target;
     const updater = isEdit ? setEditTicket : setNewTicket;
 
     updater((prev) => {
-      const next = { ...prev, [name]: value };
+      let next = { ...prev, [name]: value };
 
-      if ((name === 'saleStartDate') && next.saleEndDate && next.saleEndDate < value) {
+      // 판매 시작일 제약: 게시기간 내로 클램프
+      if (name === 'saleStartDate' && value) {
+        let v = value;
+        if (expoLoaded) {
+          if (displayStartDate && v < displayStartDate) v = displayStartDate;
+          if (displayEndDate && v > displayEndDate) v = displayEndDate;
+        }
+        next.saleStartDate = v;
+
+        // 시작일 변경 시 종료일 보정: 종료일 >= 시작일 && 종료일 <= 게시 종료일
+        if (next.saleEndDate && next.saleEndDate < v) next.saleEndDate = v;
+        if (expoLoaded && displayEndDate && next.saleEndDate && next.saleEndDate > displayEndDate)
+          next.saleEndDate = displayEndDate;
+
+        // 사용 시작/종료일도 시작일보다 빠를 수 없음(기존 규칙 유지)
+        if (next.useStartDate && next.useStartDate < v) next.useStartDate = v;
+        if (next.useEndDate && next.useEndDate < (next.useStartDate || v))
+          next.useEndDate = next.useStartDate || v;
+      }
+
+      // 판매 종료일 제약: 종료일 ∈ [판매 시작일, 게시 종료일]
+      if (name === 'saleEndDate' && value) {
+        let v = value;
+        const minStart = next.saleStartDate || prev.saleStartDate;
+        if (minStart && v < minStart) v = minStart;
+        if (expoLoaded && displayEndDate && v > displayEndDate) v = displayEndDate;
+        next.saleEndDate = v;
+      }
+
+      // 사용 시작일 제약: 행사기간 내로 클램프 + 판매 시작일 이후
+      if (name === 'useStartDate' && value) {
+        let v = value;
+        if (expoLoaded) {
+          if (expoStartDate && v < expoStartDate) v = expoStartDate;
+          if (expoEndDate && v > expoEndDate) v = expoEndDate;
+        }
+        const minBySale = next.saleStartDate || prev.saleStartDate;
+        if (minBySale && v < minBySale) v = minBySale;
+        next.useStartDate = v;
+
+        // 종료일 보정: 종료일 >= 사용 시작일 && 종료일 <= 행사 종료일
+        if (next.useEndDate && next.useEndDate < v) next.useEndDate = v;
+        if (expoLoaded && expoEndDate && next.useEndDate && next.useEndDate > expoEndDate)
+          next.useEndDate = expoEndDate;
+      }
+
+      // 사용 종료일 제약: 종료일 ∈ [사용 시작일, 행사 종료일]
+      if (name === 'useEndDate' && value) {
+        let v = value;
+        const minUseStart = next.useStartDate || prev.useStartDate;
+        if (minUseStart && v < minUseStart) v = minUseStart;
+        if (expoLoaded && expoEndDate && v > expoEndDate) v = expoEndDate;
+        next.useEndDate = v;
+      }
+
+      // 기존 보정: 종료일이 시작일보다 빠르면 동기화
+      if (name === 'saleStartDate' && next.saleEndDate && next.saleEndDate < value) {
         next.saleEndDate = value;
       }
-      if ((name === 'useStartDate') && next.useEndDate && next.useEndDate < value) {
+      if (name === 'useStartDate' && next.useEndDate && next.useEndDate < value) {
         next.useEndDate = value;
       }
+
       return next;
     });
   };
@@ -218,6 +310,7 @@ function TicketSettingForm() {
                   onChange={(e) => handleChange(e, true)}
                   className={styles.input}
                 >
+                  <option value="">타입 선택</option>
                   <option value="얼리버드">얼리버드</option>
                   <option value="일반">일반</option>
                 </select>
@@ -247,6 +340,8 @@ function TicketSettingForm() {
                 value={ticket.saleStartDate || ''}
                 onChange={(e) => handleChange(e, true)}
                 className={styles.input}
+                min={expoLoaded && displayStartDate ? displayStartDate : undefined}
+                max={expoLoaded && displayEndDate ? displayEndDate : undefined}
               />
               <span>~</span>
               <input
@@ -255,7 +350,12 @@ function TicketSettingForm() {
                 value={ticket.saleEndDate || ''}
                 onChange={(e) => handleChange(e, true)}
                 className={styles.input}
-                min={ticket.saleStartDate || undefined}
+                min={
+                  (ticket.saleStartDate ||
+                    (expoLoaded && displayStartDate ? displayStartDate : undefined)) ||
+                  undefined
+                }
+                max={expoLoaded && displayEndDate ? displayEndDate : undefined}
               />
             </div>
           ) : (
@@ -273,6 +373,18 @@ function TicketSettingForm() {
                 value={ticket.useStartDate || ''}
                 onChange={(e) => handleChange(e, true)}
                 className={styles.input}
+                min={
+                  // 행사 시작일 또는 판매 시작일 중 더 늦은 날짜가 최소
+                  ((() => {
+                    const cands = [];
+                    if (expoLoaded && expoStartDate) cands.push(expoStartDate);
+                    const saleStart = ticket.saleStartDate;
+                    if (saleStart) cands.push(saleStart);
+                    if (!cands.length) return undefined;
+                    return cands.sort()[cands.length - 1]; // 문자열 YYYY-MM-DD 정렬 안전
+                  })())
+                }
+                max={expoLoaded && expoEndDate ? expoEndDate : undefined}
               />
               <span>~</span>
               <input
@@ -281,7 +393,8 @@ function TicketSettingForm() {
                 value={ticket.useEndDate || ''}
                 onChange={(e) => handleChange(e, true)}
                 className={styles.input}
-                min={ticket.useStartDate || undefined}
+                min={ticket.useStartDate || (expoLoaded && expoStartDate ? expoStartDate : undefined)}
+                max={expoLoaded && expoEndDate ? expoEndDate : undefined}
               />
             </div>
           ) : (
@@ -292,13 +405,21 @@ function TicketSettingForm() {
         <td className={styles.td}>
           {isEdit ? (
             <div className={styles.actionGroup}>
-              <button className={styles.submitBtn} onClick={handleUpdate}>저장</button>
-              <button className={styles.cancelBtn} onClick={handleCancelEdit}>취소</button>
+              <button className={styles.submitBtn} onClick={handleUpdate}>
+                저장
+              </button>
+              <button className={styles.cancelBtn} onClick={handleCancelEdit}>
+                취소
+              </button>
             </div>
           ) : (
             <>
-              <button className={styles.editBtn} onClick={() => handleEdit(idx)}>수정</button>
-              <button className={styles.deleteBtn} onClick={() => handleDelete(idx)}>삭제</button>
+              <button className={styles.editBtn} onClick={() => handleEdit(idx)}>
+                수정
+              </button>
+              <button className={styles.deleteBtn} onClick={() => handleDelete(idx)}>
+                삭제
+              </button>
             </>
           )}
         </td>
@@ -312,8 +433,7 @@ function TicketSettingForm() {
       <div className={styles.alertBox}>
         <FaInfoCircle className={styles.alertIcon} />
         <span className={styles.alertText}>
-          <strong>안내 :</strong>&nbsp;
-          사용자들의 예매가 완료된 이후로는 티켓 정보를 변경할 수 없습니다.
+          <strong>안내 :</strong>&nbsp; 사용자들의 예매가 완료된 이후로는 티켓 정보를 변경할 수 없습니다.
         </span>
       </div>
 
@@ -350,6 +470,7 @@ function TicketSettingForm() {
                         onChange={handleChange}
                         className={styles.input}
                       >
+                        <option value="">타입 선택</option>
                         <option value="얼리버드">얼리버드</option>
                         <option value="일반">일반</option>
                       </select>
@@ -365,6 +486,7 @@ function TicketSettingForm() {
                     )}
                   </td>
                 ))}
+
                 {/* 판매 기간 */}
                 <td className={styles.td}>
                   <div className={styles.dateRange}>
@@ -374,6 +496,8 @@ function TicketSettingForm() {
                       value={newTicket.saleStartDate}
                       onChange={handleChange}
                       className={styles.input}
+                      min={expoLoaded && displayStartDate ? displayStartDate : undefined}
+                      max={expoLoaded && displayEndDate ? displayEndDate : undefined}
                     />
                     <span>~</span>
                     <input
@@ -382,10 +506,16 @@ function TicketSettingForm() {
                       value={newTicket.saleEndDate}
                       onChange={handleChange}
                       className={styles.input}
-                      min={newTicket.saleStartDate || undefined}
+                      min={
+                        (newTicket.saleStartDate ||
+                          (expoLoaded && displayStartDate ? displayStartDate : undefined)) ||
+                        undefined
+                      }
+                      max={expoLoaded && displayEndDate ? displayEndDate : undefined}
                     />
                   </div>
                 </td>
+
                 {/* 사용 기간 */}
                 <td className={styles.td}>
                   <div className={styles.dateRange}>
@@ -395,6 +525,17 @@ function TicketSettingForm() {
                       value={newTicket.useStartDate}
                       onChange={handleChange}
                       className={styles.input}
+                      min={
+                        (()=>{
+                          const cands = [];
+                          if (expoLoaded && expoStartDate) cands.push(expoStartDate);
+                          const saleStart = newTicket.saleStartDate;
+                          if (saleStart) cands.push(saleStart);
+                          if (!cands.length) return undefined;
+                          return cands.sort()[cands.length - 1];
+                        })()
+                      }
+                      max={expoLoaded && expoEndDate ? expoEndDate : undefined}
                     />
                     <span>~</span>
                     <input
@@ -403,14 +544,20 @@ function TicketSettingForm() {
                       value={newTicket.useEndDate}
                       onChange={handleChange}
                       className={styles.input}
-                      min={newTicket.useStartDate || undefined}
+                      min={newTicket.useStartDate || (expoLoaded && expoStartDate ? expoStartDate : undefined)}
+                      max={expoLoaded && expoEndDate ? expoEndDate : undefined}
                     />
                   </div>
                 </td>
+
                 <td className={styles.td}>
                   <div className={styles.actionGroup}>
-                    <button className={styles.submitBtn} onClick={handleSave}>저장</button>
-                    <button className={styles.cancelBtn} onClick={handleCancel}>취소</button>
+                    <button className={styles.submitBtn} onClick={handleSave}>
+                      저장
+                    </button>
+                    <button className={styles.cancelBtn} onClick={handleCancel}>
+                      취소
+                    </button>
                   </div>
                 </td>
               </tr>

--- a/src/expo-admin/components/ticketSettingForm/TicketSettingForm.jsx
+++ b/src/expo-admin/components/ticketSettingForm/TicketSettingForm.jsx
@@ -1,39 +1,39 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { FaPlus, FaInfoCircle } from 'react-icons/fa';
 import styles from './TicketSettingForm.module.css';
-import ToastSuccess from '../../../common/components/toastSuccess/ToastSuccess';
-import ToastFail from '../../../common/components/toastFail/ToastFail';
-import {
-  getMyExpoTickets,
-  saveMyExpoTicket,
-  deleteMyExpoTicket,
-  updateMyExpoTicket,
-} from '../../../api/service/expo-admin/setting/TicketService';
+import { FaCheckCircle, FaTimesCircle, FaTimes } from 'react-icons/fa';
 import { getMyExpoInfo } from '../../../api/service/expo-admin/setting/ExpoInfoService';
 
-function TicketSettingForm() {
+function TicketSettingForm({ open, onClose, onSubmit, editingTicket }) {
   const { expoId } = useParams();
-  const [data, setData] = useState([]);
-  const [isAdding, setIsAdding] = useState(false);
-  const [editingIndex, setEditingIndex] = useState(null);
-  const [newTicket, setNewTicket] = useState(initTicket());
-  const [editTicket, setEditTicket] = useState(initTicket());
-  const [showSuccessToast, setShowSuccessToast] = useState(false);
-  const [showFailToast, setShowFailToast] = useState(false);
-  const [failMessage, setFailMessage] = useState('');
 
-  // 게시(노출) 기간 (판매 시작/종료일을 이 범위에 묶기 위함)
+  const [form, setForm] = useState(initForm());
+  const [expoLoaded, setExpoLoaded] = useState(false);
+
+  // 게시(노출) 기간
   const [displayStartDate, setDisplayStartDate] = useState('');
   const [displayEndDate, setDisplayEndDate] = useState('');
-  // 행사(운영) 기간 (사용 시작/종료일을 이 범위에 묶기 위함)
+  // 행사(운영) 기간
   const [expoStartDate, setExpoStartDate] = useState('');
   const [expoEndDate, setExpoEndDate] = useState('');
 
-  // expo 정보 로딩 여부 (제약 적용 시점 제어)
-  const [expoLoaded, setExpoLoaded] = useState(false);
+  // 에러 상태 (필드별 메시지)
+  const [errors, setErrors] = useState({});
 
-  function initTicket() {
+  // 포커스 이동을 위한 ref 맵
+  const refs = {
+    name: useRef(null),
+    type: useRef(null),
+    description: useRef(null),
+    price: useRef(null),
+    totalQuantity: useRef(null),
+    saleStartDate: useRef(null),
+    saleEndDate: useRef(null),
+    useStartDate: useRef(null),
+    useEndDate: useRef(null),
+  };
+
+  function initForm() {
     return {
       ticketId: null,
       name: '',
@@ -48,526 +48,470 @@ function TicketSettingForm() {
     };
   }
 
-  // 초기 로딩: 티켓 + 박람회 정보(게시기간/행사기간)
+  // 모달 열릴 때 스크롤 잠금
   useEffect(() => {
-    const fetchAll = async () => {
+    if (!open) return;
+    const original = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    const onKey = (e) => e.key === 'Escape' && onClose?.();
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.body.style.overflow = original;
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open, onClose]);
+
+  // 제약(박람회 기간/게시기간) 로드
+  useEffect(() => {
+    if (!open || !expoId) return;
+    let mounted = true;
+    (async () => {
       try {
-        const [ticketData, expoInfo] = await Promise.all([
-          getMyExpoTickets(expoId),
-          getMyExpoInfo(expoId),
-        ]);
-        setData(ticketData || []);
-        setDisplayStartDate(expoInfo?.displayStartDate?.split('T')[0] || '');
-        setDisplayEndDate(expoInfo?.displayEndDate?.split('T')[0] || '');
-        setExpoStartDate(expoInfo?.startDate?.split('T')[0] || '');
-        setExpoEndDate(expoInfo?.endDate?.split('T')[0] || '');
+        const expo = await getMyExpoInfo(expoId);
+        if (!mounted) return;
+        setDisplayStartDate(expo?.displayStartDate?.split('T')[0] || '');
+        setDisplayEndDate(expo?.displayEndDate?.split('T')[0] || '');
+        setExpoStartDate(expo?.startDate?.split('T')[0] || '');
+        setExpoEndDate(expo?.endDate?.split('T')[0] || '');
         setExpoLoaded(true);
-      } catch (error) {
-        console.log(error.message);
-        setExpoLoaded(true); // 실패해도 폼은 사용 가능하도록
+      } catch (e) {
+        setExpoLoaded(true); // 실패해도 폼 사용 가능
       }
+    })();
+    return () => {
+      mounted = false;
     };
-    if (expoId) fetchAll();
-  }, [expoId]);
+  }, [open, expoId]);
 
-  // 성공 토스트
-  const triggerSuccessToast = () => {
-    setShowSuccessToast(true);
-    setTimeout(() => setShowSuccessToast(false), 3000);
+  // 모달 열림/수정 모드 전환 시 폼 초기화 + 에러 초기화
+  useEffect(() => {
+    if (editingTicket) setForm(editingTicket);
+    else setForm(initForm());
+    setErrors({});
+  }, [editingTicket, open]);
+
+  // YYYY-MM-DD 범위 클램프
+  const clampDate = (v, min, max) => {
+    if (!v) return v;
+    let nv = v;
+    if (min && nv < min) nv = min;
+    if (max && nv > max) nv = max;
+    return nv;
   };
 
-  // 실패 토스트
-  const triggerToastFail = (message) => {
-    setFailMessage(message);
-    setShowFailToast(true);
-    setTimeout(() => setShowFailToast(false), 3000);
-  };
-
-  // 유효성 검사 (백엔드 DTO 규칙 + 게시/행사 기간 제약 반영)
-  const validateTicket = (t) => {
-    if (!t.name || t.name.trim() === '') return '티켓 이름은 필수입니다.';
-    if (t.name.length > 100) return '티켓 이름은 100자 이하여야 합니다.';
-    if (!t.description || t.description.trim() === '') return '설명은 필수입니다.';
-    if (!t.type) return '타입은 필수입니다.';
-
-    if (t.price === '' || isNaN(t.price)) return '가격은 숫자여야 합니다.';
-    if (Number(t.price) < 0) return '가격은 0원 이상이어야 합니다.';
-
-    if (t.totalQuantity === '' || isNaN(t.totalQuantity)) return '수량은 숫자여야 합니다.';
-    if (Number(t.totalQuantity) < 1) return '수량은 1장 이상이어야 합니다.';
-
-    if (!t.saleStartDate) return '판매 시작일은 필수입니다.';
-    if (!t.saleEndDate) return '판매 종료일은 필수입니다.';
-    if (t.saleEndDate < t.saleStartDate) return '판매 종료일은 시작일과 같거나 이후여야 합니다.';
-
-    // 게시기간 내 제약 (존재할 때만 검사)
-    if (displayStartDate && t.saleStartDate < displayStartDate)
-      return '판매 시작일은 게시 시작일과 같거나 이후여야 합니다.';
-    if (displayEndDate && t.saleStartDate > displayEndDate)
-      return '판매 시작일은 게시 종료일과 같거나 이전이어야 합니다.';
-    if (displayEndDate && t.saleEndDate > displayEndDate)
-      return '판매 종료일은 게시 종료일과 같거나 이전이어야 합니다.';
-
-    if (!t.useStartDate) return '사용 시작일은 필수입니다.';
-    if (!t.useEndDate) return '사용 종료일은 필수입니다.';
-    if (t.useEndDate < t.useStartDate) return '사용 종료일은 시작일과 같거나 이후여야 합니다.';
-    if (t.useStartDate < t.saleStartDate) return '사용 시작일은 판매 시작일과 같거나 이후여야 합니다.';
-
-    // 행사기간 내 제약 (존재할 때만 검사)
-    if (expoStartDate && t.useStartDate < expoStartDate)
-      return '사용 시작일은 행사 시작일과 같거나 이후여야 합니다.';
-    if (expoEndDate && t.useEndDate > expoEndDate)
-      return '사용 종료일은 행사 종료일과 같거나 이전이어야 합니다.';
-
-    return null;
-  };
-
-  // 저장(추가)
-  const handleSave = async () => {
-    const error = validateTicket(newTicket);
-    if (error) {
-      triggerToastFail(error);
-      return;
-    }
-
-    const payload = {
-      ...newTicket,
-      price: Number(newTicket.price),
-      totalQuantity: Number(newTicket.totalQuantity),
-    };
-
-    try {
-      const created = await saveMyExpoTicket(expoId, payload);
-      triggerSuccessToast();
-      setData([...data, created]);
-      setNewTicket(initTicket());
-      setIsAdding(false);
-    } catch (error) {
-      triggerToastFail(error.message);
-    }
-  };
-
-  // 삭제
-  const handleDelete = async (index) => {
-    const ticketId = data[index]?.ticketId;
-    if (!ticketId) {
-      triggerToastFail('티켓 ID가 없습니다.');
-      return;
-    }
-    const confirmed = window.confirm('정말 삭제하시겠습니까?');
-    if (!confirmed) return;
-
-    try {
-      await deleteMyExpoTicket(expoId, ticketId);
-      setData((prev) => prev.filter((_, i) => i !== index));
-      triggerSuccessToast();
-      if (editingIndex === index) setEditingIndex(null);
-    } catch (err) {
-      triggerToastFail(err.message);
-    }
-  };
-
-  // 수정 저장
-  const handleUpdate = async () => {
-    const error = validateTicket(editTicket);
-    if (error) {
-      triggerToastFail(error);
-      return;
-    }
-
-    const payload = {
-      ...editTicket,
-      price: Number(editTicket.price),
-      totalQuantity: Number(editTicket.totalQuantity),
-    };
-
-    try {
-      const updated = await updateMyExpoTicket(expoId, editTicket.ticketId, payload);
-      const newData = [...data];
-      newData[editingIndex] = updated;
-      setData(newData);
-      setEditingIndex(null);
-      triggerSuccessToast();
-    } catch (error) {
-      triggerToastFail(error.message);
-    }
-  };
-
-  // 추가 취소
-  const handleCancel = () => {
-    setIsAdding(false);
-    setNewTicket(initTicket());
-  };
-
-  // 수정 진입
-  const handleEdit = (index) => {
-    setEditingIndex(index);
-    setEditTicket(data[index]);
-    setIsAdding(false);
-  };
-
-  // 수정 취소
-  const handleCancelEdit = () => {
-    setEditingIndex(null);
-    setEditTicket(initTicket());
-  };
-
-  // 공용 input 변경 핸들러 (게시/행사 기간 제약 즉시 보정: 기준값 존재 시에만)
-  const handleChange = (e, isEdit = false) => {
+  const handleChange = (e) => {
     const { name, value } = e.target;
-    const updater = isEdit ? setEditTicket : setNewTicket;
 
-    updater((prev) => {
+    setForm((prev) => {
       let next = { ...prev, [name]: value };
 
-      // 판매 시작일 제약: 게시기간 내로 클램프
-      if (name === 'saleStartDate' && value) {
-        let v = value;
-        if (expoLoaded) {
-          if (displayStartDate && v < displayStartDate) v = displayStartDate;
-          if (displayEndDate && v > displayEndDate) v = displayEndDate;
-        }
-        next.saleStartDate = v;
+      // 판매 시작일: 게시기간 내로 클램프
+      if (name === 'saleStartDate') {
+        const clamped = expoLoaded
+          ? clampDate(value, displayStartDate || undefined, displayEndDate || undefined)
+          : value;
+        next.saleStartDate = clamped;
 
-        // 시작일 변경 시 종료일 보정: 종료일 >= 시작일 && 종료일 <= 게시 종료일
-        if (next.saleEndDate && next.saleEndDate < v) next.saleEndDate = v;
-        if (expoLoaded && displayEndDate && next.saleEndDate && next.saleEndDate > displayEndDate)
+        // 종료일 보정
+        if (next.saleEndDate && next.saleEndDate < clamped) next.saleEndDate = clamped;
+        if (expoLoaded && displayEndDate && next.saleEndDate && next.saleEndDate > displayEndDate) {
           next.saleEndDate = displayEndDate;
-
-        // 사용 시작/종료일도 시작일보다 빠를 수 없음(기존 규칙 유지)
-        if (next.useStartDate && next.useStartDate < v) next.useStartDate = v;
-        if (next.useEndDate && next.useEndDate < (next.useStartDate || v))
-          next.useEndDate = next.useStartDate || v;
-      }
-
-      // 판매 종료일 제약: 종료일 ∈ [판매 시작일, 게시 종료일]
-      if (name === 'saleEndDate' && value) {
-        let v = value;
-        const minStart = next.saleStartDate || prev.saleStartDate;
-        if (minStart && v < minStart) v = minStart;
-        if (expoLoaded && displayEndDate && v > displayEndDate) v = displayEndDate;
-        next.saleEndDate = v;
-      }
-
-      // 사용 시작일 제약: 행사기간 내로 클램프 + 판매 시작일 이후
-      if (name === 'useStartDate' && value) {
-        let v = value;
-        if (expoLoaded) {
-          if (expoStartDate && v < expoStartDate) v = expoStartDate;
-          if (expoEndDate && v > expoEndDate) v = expoEndDate;
         }
+        // 사용일 보정
+        if (next.useStartDate && next.useStartDate < clamped) next.useStartDate = clamped;
+        if (next.useEndDate && next.useEndDate < (next.useStartDate || clamped)) {
+          next.useEndDate = next.useStartDate || clamped;
+        }
+      }
+
+      // 판매 종료일: [판매 시작일, 게시 종료일]
+      if (name === 'saleEndDate') {
+        const minStart = next.saleStartDate || prev.saleStartDate;
+        next.saleEndDate = expoLoaded
+          ? clampDate(value, minStart || displayStartDate || undefined, displayEndDate || undefined)
+          : value;
+      }
+
+      // 사용 시작일: 행사기간 내 + 판매 시작일 이후
+      if (name === 'useStartDate') {
         const minBySale = next.saleStartDate || prev.saleStartDate;
-        if (minBySale && v < minBySale) v = minBySale;
-        next.useStartDate = v;
+        let min = expoStartDate || undefined;
+        if (minBySale) min = min ? (minBySale > min ? minBySale : min) : minBySale;
+        const clamped = expoLoaded ? clampDate(value, min, expoEndDate || undefined) : value;
+        next.useStartDate = clamped;
 
-        // 종료일 보정: 종료일 >= 사용 시작일 && 종료일 <= 행사 종료일
-        if (next.useEndDate && next.useEndDate < v) next.useEndDate = v;
-        if (expoLoaded && expoEndDate && next.useEndDate && next.useEndDate > expoEndDate)
+        // 종료일 보정
+        if (next.useEndDate && next.useEndDate < clamped) next.useEndDate = clamped;
+        if (expoLoaded && expoEndDate && next.useEndDate && next.useEndDate > expoEndDate) {
           next.useEndDate = expoEndDate;
+        }
       }
 
-      // 사용 종료일 제약: 종료일 ∈ [사용 시작일, 행사 종료일]
-      if (name === 'useEndDate' && value) {
-        let v = value;
-        const minUseStart = next.useStartDate || prev.useStartDate;
-        if (minUseStart && v < minUseStart) v = minUseStart;
-        if (expoLoaded && expoEndDate && v > expoEndDate) v = expoEndDate;
-        next.useEndDate = v;
+      // 사용 종료일: [사용 시작일, 행사 종료일]
+      if (name === 'useEndDate') {
+        const minUseStart = next.useStartDate || prev.useStartDate || expoStartDate || undefined;
+        next.useEndDate = expoLoaded
+          ? clampDate(value, minUseStart, expoEndDate || undefined)
+          : value;
       }
 
-      // 기존 보정: 종료일이 시작일보다 빠르면 동기화
-      if (name === 'saleStartDate' && next.saleEndDate && next.saleEndDate < value) {
-        next.saleEndDate = value;
+      // 안전장치
+      if (name === 'saleStartDate' && next.saleEndDate && next.saleEndDate < next.saleStartDate) {
+        next.saleEndDate = next.saleStartDate;
       }
-      if (name === 'useStartDate' && next.useEndDate && next.useEndDate < value) {
-        next.useEndDate = value;
+      if (name === 'useStartDate' && next.useEndDate && next.useEndDate < next.useStartDate) {
+        next.useEndDate = next.useStartDate;
       }
 
       return next;
     });
+
+    // 필드 수정 시 해당 에러 즉시 제거
+    setErrors((prev) => ({ ...prev, [name]: '' }));
   };
 
-  // 추가 행 열기
-  const handleAddClick = () => {
-    setIsAdding(true);
-    setEditingIndex(null);
-    setNewTicket(initTicket());
+  // 사용 시작일 input용 min 계산 (행사 시작 vs 판매 시작 중 늦은 날짜)
+  const minUseStart = useMemo(() => {
+    const cands = [];
+    if (expoStartDate) cands.push(expoStartDate);
+    if (form.saleStartDate) cands.push(form.saleStartDate);
+    if (!cands.length) return undefined;
+    return cands.sort()[cands.length - 1];
+  }, [expoStartDate, form.saleStartDate]);
+
+  // ============== 유효성 검사 (백엔드 DTO 매칭) ==============
+  const isBlank = (s) => !s || String(s).trim() === '';
+
+  const runValidation = () => {
+    const e = {};
+
+    // 왼쪽 컬럼 순서(이름 → 타입 → 설명)
+    if (isBlank(form.name)) e.name = '티켓 이름은 필수입니다.';
+    else if (form.name.length > 100) e.name = '티켓 이름은 100자 이하여야 합니다.';
+
+    if (isBlank(e.name)) {
+      if (isBlank(form.type)) e.type = '티켓 타입은 필수입니다.';
+    }
+
+    if (isBlank(e.name) && isBlank(e.type)) {
+      if (isBlank(form.description)) e.description = '티켓 설명은 필수입니다.';
+    }
+
+    // 오른쪽 컬럼 순서(가격 → 수량 → 판매기간 → 사용기간)
+    if (isBlank(e.name) && isBlank(e.type) && isBlank(e.description)) {
+      if (form.price === '' || form.price === null) e.price = '티켓 가격은 필수입니다.';
+      else if (isNaN(Number(form.price))) e.price = '가격은 숫자여야 합니다.';
+      else if (Number(form.price) < 0) e.price = '가격은 0원 이상이어야 합니다.';
+    }
+
+    if (isBlank(e.name) && isBlank(e.type) && isBlank(e.description) && isBlank(e.price)) {
+      if (form.totalQuantity === '' || form.totalQuantity === null)
+        e.totalQuantity = '티켓 수량은 필수입니다.';
+      else if (isNaN(Number(form.totalQuantity)))
+        e.totalQuantity = '티켓 수량은 숫자여야 합니다.';
+      else if (Number(form.totalQuantity) < 1)
+        e.totalQuantity = '티켓 수량은 1장 이상이어야 합니다.';
+    }
+
+    if (
+      isBlank(e.name) &&
+      isBlank(e.type) &&
+      isBlank(e.description) &&
+      isBlank(e.price) &&
+      isBlank(e.totalQuantity)
+    ) {
+      if (isBlank(form.saleStartDate)) e.saleStartDate = '판매 시작일은 필수입니다.';
+      if (isBlank(form.saleEndDate)) e.saleEndDate = '판매 종료일은 필수입니다.';
+
+      if (isBlank(e.saleStartDate) && isBlank(e.saleEndDate)) {
+        if (form.saleEndDate < form.saleStartDate) {
+          e.saleEndDate = '판매 종료일은 시작일과 같거나 이후여야 합니다.';
+        }
+        // 게시기간 제약(있을 때만)
+        if (displayStartDate && form.saleStartDate && form.saleStartDate < displayStartDate) {
+          e.saleStartDate = '판매 시작일은 게시 시작일과 같거나 이후여야 합니다.';
+        }
+        if (displayEndDate && form.saleStartDate && form.saleStartDate > displayEndDate) {
+          e.saleStartDate = '판매 시작일은 게시 종료일과 같거나 이전이어야 합니다.';
+        }
+        if (displayEndDate && form.saleEndDate && form.saleEndDate > displayEndDate) {
+          e.saleEndDate = '판매 종료일은 게시 종료일과 같거나 이전이어야 합니다.';
+        }
+      }
+    }
+
+    if (
+      isBlank(e.name) &&
+      isBlank(e.type) &&
+      isBlank(e.description) &&
+      isBlank(e.price) &&
+      isBlank(e.totalQuantity) &&
+      isBlank(e.saleStartDate) &&
+      isBlank(e.saleEndDate)
+    ) {
+      if (isBlank(form.useStartDate)) e.useStartDate = '사용 시작일은 필수입니다.';
+      if (isBlank(form.useEndDate)) e.useEndDate = '사용 종료일은 필수입니다.';
+
+      if (isBlank(e.useStartDate) && isBlank(e.useEndDate)) {
+        if (form.useEndDate < form.useStartDate) {
+          e.useEndDate = '사용 종료일은 시작일과 같거나 이후여야 합니다.';
+        }
+        if (form.useStartDate < form.saleStartDate) {
+          e.useStartDate = '사용 시작일은 판매 시작일과 같거나 이후여야 합니다.';
+        }
+        // 행사기간 제약(있을 때만)
+        if (expoStartDate && form.useStartDate && form.useStartDate < expoStartDate) {
+          e.useStartDate = '사용 시작일은 행사 시작일과 같거나 이후여야 합니다.';
+        }
+        if (expoEndDate && form.useEndDate && form.useEndDate > expoEndDate) {
+          e.useEndDate = '사용 종료일은 행사 종료일과 같거나 이전이어야 합니다.';
+        }
+      }
+    }
+
+    return e;
   };
 
-  const renderRow = (row, idx) => {
-    const isEdit = editingIndex === idx;
-    const ticket = isEdit ? editTicket : row;
-
-    return (
-      <tr key={idx} className={styles.row}>
-        {['name', 'type', 'description', 'price', 'totalQuantity'].map((field) => (
-          <td key={field} className={styles.td}>
-            {isEdit ? (
-              field === 'type' ? (
-                <select
-                  name="type"
-                  value={ticket.type}
-                  onChange={(e) => handleChange(e, true)}
-                  className={styles.input}
-                >
-                  <option value="">타입 선택</option>
-                  <option value="얼리버드">얼리버드</option>
-                  <option value="일반">일반</option>
-                </select>
-              ) : (
-                <input
-                  name={field}
-                  type={field === 'price' || field === 'totalQuantity' ? 'number' : 'text'}
-                  value={ticket[field]}
-                  onChange={(e) => handleChange(e, true)}
-                  className={styles.input}
-                  min={field === 'price' ? 0 : field === 'totalQuantity' ? 1 : undefined}
-                />
-              )
-            ) : (
-              ticket[field]
-            )}
-          </td>
-        ))}
-
-        {/* 판매 기간 */}
-        <td className={styles.td}>
-          {isEdit ? (
-            <div className={styles.dateRange}>
-              <input
-                name="saleStartDate"
-                type="date"
-                value={ticket.saleStartDate || ''}
-                onChange={(e) => handleChange(e, true)}
-                className={styles.input}
-                min={expoLoaded && displayStartDate ? displayStartDate : undefined}
-                max={expoLoaded && displayEndDate ? displayEndDate : undefined}
-              />
-              <span>~</span>
-              <input
-                name="saleEndDate"
-                type="date"
-                value={ticket.saleEndDate || ''}
-                onChange={(e) => handleChange(e, true)}
-                className={styles.input}
-                min={
-                  (ticket.saleStartDate ||
-                    (expoLoaded && displayStartDate ? displayStartDate : undefined)) ||
-                  undefined
-                }
-                max={expoLoaded && displayEndDate ? displayEndDate : undefined}
-              />
-            </div>
-          ) : (
-            `${ticket.saleStartDate} ~ ${ticket.saleEndDate}`
-          )}
-        </td>
-
-        {/* 사용 기간 */}
-        <td className={styles.td}>
-          {isEdit ? (
-            <div className={styles.dateRange}>
-              <input
-                name="useStartDate"
-                type="date"
-                value={ticket.useStartDate || ''}
-                onChange={(e) => handleChange(e, true)}
-                className={styles.input}
-                min={
-                  // 행사 시작일 또는 판매 시작일 중 더 늦은 날짜가 최소
-                  ((() => {
-                    const cands = [];
-                    if (expoLoaded && expoStartDate) cands.push(expoStartDate);
-                    const saleStart = ticket.saleStartDate;
-                    if (saleStart) cands.push(saleStart);
-                    if (!cands.length) return undefined;
-                    return cands.sort()[cands.length - 1]; // 문자열 YYYY-MM-DD 정렬 안전
-                  })())
-                }
-                max={expoLoaded && expoEndDate ? expoEndDate : undefined}
-              />
-              <span>~</span>
-              <input
-                name="useEndDate"
-                type="date"
-                value={ticket.useEndDate || ''}
-                onChange={(e) => handleChange(e, true)}
-                className={styles.input}
-                min={ticket.useStartDate || (expoLoaded && expoStartDate ? expoStartDate : undefined)}
-                max={expoLoaded && expoEndDate ? expoEndDate : undefined}
-              />
-            </div>
-          ) : (
-            `${ticket.useStartDate} ~ ${ticket.useEndDate}`
-          )}
-        </td>
-
-        <td className={styles.td}>
-          {isEdit ? (
-            <div className={styles.actionGroup}>
-              <button className={styles.submitBtn} onClick={handleUpdate}>
-                저장
-              </button>
-              <button className={styles.cancelBtn} onClick={handleCancelEdit}>
-                취소
-              </button>
-            </div>
-          ) : (
-            <>
-              <button className={styles.editBtn} onClick={() => handleEdit(idx)}>
-                수정
-              </button>
-              <button className={styles.deleteBtn} onClick={() => handleDelete(idx)}>
-                삭제
-              </button>
-            </>
-          )}
-        </td>
-      </tr>
-    );
+  const focusFirstError = (e) => {
+    const order = [
+      'name',
+      'type',
+      'description',
+      'price',
+      'totalQuantity',
+      'saleStartDate',
+      'saleEndDate',
+      'useStartDate',
+      'useEndDate',
+    ];
+    for (const key of order) {
+      if (e[key]) {
+        refs[key]?.current?.focus?.();
+        break;
+      }
+    }
   };
+
+  const handleSubmit = async () => {
+    const e = runValidation();
+    setErrors(e);
+    if (Object.values(e).some(Boolean)) {
+      focusFirstError(e);
+      return;
+    }
+
+    const payload = {
+      ...form,
+      price: form.price === '' ? '' : Number(form.price),
+      totalQuantity: form.totalQuantity === '' ? '' : Number(form.totalQuantity),
+    };
+    const success = await onSubmit(payload);
+    if (success) {
+      setForm(initForm());
+      setErrors({});
+      onClose?.();
+    }
+  };
+
+  const handleCancel = () => {
+    setForm(initForm());
+    setErrors({});
+    onClose?.();
+  };
+
+  if (!open) return null;
 
   return (
-    <div className={styles.container}>
-      {/* 안내 박스 */}
-      <div className={styles.alertBox}>
-        <FaInfoCircle className={styles.alertIcon} />
-        <span className={styles.alertText}>
-          <strong>안내 :</strong>&nbsp; 사용자들의 예매가 완료된 이후로는 티켓 정보를 변경할 수 없습니다.
-        </span>
-      </div>
+    <div className={styles.backdrop} onClick={onClose} role="dialog" aria-modal="true">
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        {/* 헤더 */}
+        <div className={styles.modalHeader}>
+          <h3 className={styles.modalTitle}>{editingTicket ? '티켓 수정' : '티켓 등록'}</h3>
+          <button className={styles.closeBtn} onClick={onClose} aria-label="닫기">
+            <FaTimes className={styles.closeIcon} />
+          </button>
+        </div>
 
-      <div className={styles.header}>
-        <button className={styles.addBtn} onClick={handleAddClick}>
-          <FaPlus className={styles.iconBtn} /> 티켓 등록
-        </button>
-      </div>
+        {/* 컨텐츠 */}
+        <div className={styles.modalContent}>
+          <div className={styles.container}>
+            <div className={styles.formGrid}>
+              {/* 왼쪽 컬럼: 기본 정보 */}
+              <div className={styles.column}>
+                <div className={styles.formGroup}>
+                  <label className={styles.label}>티켓 이름</label>
+                  <input
+                    ref={refs.name}
+                    name="name"
+                    className={styles.inputField}
+                    placeholder="티켓 이름 입력"
+                    value={form.name}
+                    onChange={handleChange}
+                    aria-invalid={!!errors.name}
+                  />
+                  {errors.name && <p className={styles.errorText}>{errors.name}</p>}
+                </div>
 
-      <div className={styles.tableWrapper}>
-        <table className={styles.table}>
-          <thead>
-            <tr className={styles.headerRow}>
-              <th className={styles.th}>티켓 이름</th>
-              <th className={styles.th}>타입</th>
-              <th className={styles.th}>설명</th>
-              <th className={styles.th}>가격(원)</th>
-              <th className={styles.th}>수량</th>
-              <th className={styles.th}>판매 기간</th>
-              <th className={styles.th}>사용 기간</th>
-              <th className={styles.th}>수정/삭제</th>
-            </tr>
-          </thead>
-          <tbody>
-            {data.map(renderRow)}
-            {isAdding && (
-              <tr className={styles.row}>
-                {['name', 'type', 'description', 'price', 'totalQuantity'].map((field) => (
-                  <td key={field} className={styles.td}>
-                    {field === 'type' ? (
-                      <select
-                        name="type"
-                        value={newTicket.type}
-                        onChange={handleChange}
-                        className={styles.input}
-                      >
-                        <option value="">타입 선택</option>
-                        <option value="얼리버드">얼리버드</option>
-                        <option value="일반">일반</option>
-                      </select>
-                    ) : (
-                      <input
-                        name={field}
-                        type={field === 'price' || field === 'totalQuantity' ? 'number' : 'text'}
-                        value={newTicket[field]}
-                        onChange={handleChange}
-                        className={styles.input}
-                        min={field === 'price' ? 0 : field === 'totalQuantity' ? 1 : undefined}
-                      />
-                    )}
-                  </td>
-                ))}
+                <div className={styles.formGroup}>
+                  <label className={styles.label}>타입</label>
+                  <select
+                    ref={refs.type}
+                    name="type"
+                    className={styles.inputField}
+                    value={form.type}
+                    onChange={handleChange}
+                    aria-invalid={!!errors.type}
+                  >
+                    <option value="">타입 선택</option>
+                    <option value="얼리버드">얼리버드</option>
+                    <option value="일반">일반</option>
+                  </select>
+                  {errors.type && <p className={styles.errorText}>{errors.type}</p>}
+                </div>
 
-                {/* 판매 기간 */}
-                <td className={styles.td}>
-                  <div className={styles.dateRange}>
+                <div className={styles.formGroup}>
+                  <label className={styles.label}>설명</label>
+                  <input
+                    ref={refs.description}
+                    name="description"
+                    className={styles.inputField}
+                    placeholder="설명 입력"
+                    value={form.description}
+                    onChange={handleChange}
+                    aria-invalid={!!errors.description}
+                  />
+                  {errors.description && (
+                    <p className={styles.errorText}>{errors.description}</p>
+                  )}
+                </div>
+              </div>
+
+              {/* 오른쪽 컬럼: 가격/수량 + 기간 */}
+              <div className={styles.column}>
+                <div className={styles.formGroup}>
+                  <label className={styles.label}>가격(원)</label>
+                  <input
+                    ref={refs.price}
+                    type="number"
+                    name="price"
+                    className={styles.inputField}
+                    placeholder="가격 입력"
+                    value={form.price}
+                    onChange={handleChange}
+                    min={0}
+                    aria-invalid={!!errors.price}
+                  />
+                  {errors.price && <p className={styles.errorText}>{errors.price}</p>}
+                </div>
+
+                <div className={styles.formGroup}>
+                  <label className={styles.label}>수량</label>
+                  <input
+                    ref={refs.totalQuantity}
+                    type="number"
+                    name="totalQuantity"
+                    className={styles.inputField}
+                    placeholder="수량 입력"
+                    value={form.totalQuantity}
+                    onChange={handleChange}
+                    min={1}
+                    aria-invalid={!!errors.totalQuantity}
+                  />
+                  {errors.totalQuantity && (
+                    <p className={styles.errorText}>{errors.totalQuantity}</p>
+                  )}
+                </div>
+
+                <div className={styles.formGroup}>
+                  <label className={styles.label}>판매 기간</label>
+                  <div className={styles.timeRange}>
                     <input
-                      name="saleStartDate"
+                      ref={refs.saleStartDate}
                       type="date"
-                      value={newTicket.saleStartDate}
+                      name="saleStartDate"
+                      className={styles.inputField}
+                      value={form.saleStartDate}
                       onChange={handleChange}
-                      className={styles.input}
                       min={expoLoaded && displayStartDate ? displayStartDate : undefined}
                       max={expoLoaded && displayEndDate ? displayEndDate : undefined}
+                      aria-invalid={!!errors.saleStartDate}
                     />
-                    <span>~</span>
+                    <span className={styles.timeDivider}>~</span>
                     <input
-                      name="saleEndDate"
+                      ref={refs.saleEndDate}
                       type="date"
-                      value={newTicket.saleEndDate}
+                      name="saleEndDate"
+                      className={styles.inputField}
+                      value={form.saleEndDate}
                       onChange={handleChange}
-                      className={styles.input}
                       min={
-                        (newTicket.saleStartDate ||
+                        (form.saleStartDate ||
                           (expoLoaded && displayStartDate ? displayStartDate : undefined)) ||
                         undefined
                       }
                       max={expoLoaded && displayEndDate ? displayEndDate : undefined}
+                      aria-invalid={!!errors.saleEndDate}
                     />
                   </div>
-                </td>
+                  {(errors.saleStartDate || errors.saleEndDate) && (
+                    <p className={styles.errorText}>
+                      {errors.saleStartDate || errors.saleEndDate}
+                    </p>
+                  )}
+                </div>
 
-                {/* 사용 기간 */}
-                <td className={styles.td}>
-                  <div className={styles.dateRange}>
+                <div className={styles.formGroup}>
+                  <label className={styles.label}>사용 기간</label>
+                  <div className={styles.timeRange}>
                     <input
-                      name="useStartDate"
+                      ref={refs.useStartDate}
                       type="date"
-                      value={newTicket.useStartDate}
+                      name="useStartDate"
+                      className={styles.inputField}
+                      value={form.useStartDate}
                       onChange={handleChange}
-                      className={styles.input}
+                      min={expoLoaded ? minUseStart : undefined}
+                      max={expoLoaded && expoEndDate ? expoEndDate : undefined}
+                      aria-invalid={!!errors.useStartDate}
+                    />
+                    <span className={styles.timeDivider}>~</span>
+                    <input
+                      ref={refs.useEndDate}
+                      type="date"
+                      name="useEndDate"
+                      className={styles.inputField}
+                      value={form.useEndDate}
+                      onChange={handleChange}
                       min={
-                        (()=>{
-                          const cands = [];
-                          if (expoLoaded && expoStartDate) cands.push(expoStartDate);
-                          const saleStart = newTicket.saleStartDate;
-                          if (saleStart) cands.push(saleStart);
-                          if (!cands.length) return undefined;
-                          return cands.sort()[cands.length - 1];
-                        })()
+                        form.useStartDate ||
+                        (expoLoaded && expoStartDate ? expoStartDate : undefined)
                       }
                       max={expoLoaded && expoEndDate ? expoEndDate : undefined}
-                    />
-                    <span>~</span>
-                    <input
-                      name="useEndDate"
-                      type="date"
-                      value={newTicket.useEndDate}
-                      onChange={handleChange}
-                      className={styles.input}
-                      min={newTicket.useStartDate || (expoLoaded && expoStartDate ? expoStartDate : undefined)}
-                      max={expoLoaded && expoEndDate ? expoEndDate : undefined}
+                      aria-invalid={!!errors.useEndDate}
                     />
                   </div>
-                </td>
+                  {(errors.useStartDate || errors.useEndDate) && (
+                    <p className={styles.errorText}>
+                      {errors.useStartDate || errors.useEndDate}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
 
-                <td className={styles.td}>
-                  <div className={styles.actionGroup}>
-                    <button className={styles.submitBtn} onClick={handleSave}>
-                      저장
-                    </button>
-                    <button className={styles.cancelBtn} onClick={handleCancel}>
-                      취소
-                    </button>
-                  </div>
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+            {/* 구분선 + 버튼 */}
+            <div className={styles.buttonDivider} />
+            <div className={styles.buttonGroup}>
+              <button className={`${styles.actionBtn} ${styles.submitBtn}`} onClick={handleSubmit}>
+                <FaCheckCircle className={styles.iconBtn} /> {editingTicket ? '수정' : '등록'}
+              </button>
+              <button className={`${styles.actionBtn} ${styles.cancelBtn}`} onClick={handleCancel}>
+                <FaTimesCircle className={styles.iconBtn} /> 취소
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
-
-      {showSuccessToast && <ToastSuccess />}
-      {showFailToast && <ToastFail message={failMessage} />}
     </div>
   );
 }

--- a/src/expo-admin/components/ticketSettingForm/TicketSettingForm.module.css
+++ b/src/expo-admin/components/ticketSettingForm/TicketSettingForm.module.css
@@ -1,185 +1,191 @@
+/* ===== 모달 레이어 ===== */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  width: 100%;
+  max-width: 860px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0,0,0,.15);
+  overflow: hidden;
+}
+
+.modalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid #eee;
+}
+
+.modalTitle {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.closeBtn {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 6px;
+}
+
+.closeBtn:hover {
+  background: #f5f5f5;
+}
+
+.closeIcon {
+  font-size: 16px;
+  color: #333;
+}
+
+.modalContent {
+  padding: 20px 24px;
+  max-height: calc(100vh - 200px);
+  overflow: auto;
+}
+
+/* ===== 기존 폼 스타일 (그대로) ===== */
 .container {
   width: 100%;
   font-family: 'Pretendard', sans-serif;
   display: flex;
   flex-direction: column;
+  gap: 24px;
   box-sizing: border-box;
 }
 
-.header {
+.formGrid {
   display: flex;
-  justify-content: flex-end;
+  gap: 40px;
+  width: 100%;
+}
+
+.column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+}
+
+.label {
+  font-size: 13px;
+  font-weight: 500;
+  color: #777;
+  margin-bottom: 4px;
+}
+
+.inputField {
+  padding: 10px 36px 10px 0;
+  font-size: 14px;
+  color: #333;
+  border: none;
+  border-bottom: 1px solid #ccc;
+  background-color: transparent;
+  outline: none;
+  width: 100%;
+}
+
+.inputField:focus {
+  border-color: #1e2a38;
+}
+
+.inputField:disabled {
+  color: #aaa;
+  border-bottom: 1px dashed #ccc;
+  cursor: not-allowed;
+}
+
+.inputField:disabled::placeholder {
+  color: #ccc;
+  opacity: 1;
+}
+
+.timeRange {
+  display: flex;
+  gap: 8px;
   align-items: center;
 }
 
-.addBtn {
-  background-color: #ececec;
-  color: #1e2a38;
-  font-weight: 400;
-  padding: 8px 20px;
-  font-size: 12px;
-  border: none;
-  border-radius: 20px;
+.timeDivider {
+  font-weight: bold;
+}
+
+/* 버튼 위 구분선 (점선) */
+.buttonDivider {
+  border-top: 1px dashed #ddd;
+  margin-top: 8px;
+}
+
+/* 버튼들 */
+.buttonGroup {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 0;
+}
+
+.actionBtn {
   display: flex;
   align-items: center;
   gap: 6px;
+  padding: 8px 20px;
+  font-size: 12px;
+  font-weight: 400;
+  border: none;
+  border-radius: 20px;
   cursor: pointer;
+  white-space: nowrap;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-.addBtn:hover {
-  background-color: #d9d9d9;
-  color: #1e2a38;
-}
-
-
-.tableWrapper {
-  margin-top: 24px;
-  background-color: #fff;
-  border-radius: 7px;
-  overflow-x: auto;
-}
-
-.table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.headerRow {
-  background-color: #f7f9fc;
-}
-
-.th {
-  text-align: center;
-  padding: 12px 16px;
-  font-size: 14px;
-  color: #555;
-  border-bottom: 1px solid #eee;
-  white-space: nowrap;
-}
-
-.row {
-  border-bottom: 1px solid #f0f0f0;
-}
-
-.td {
-  padding: 12px 16px;
-  font-size: 15px;
-  color: #222;
-  text-align: center;
-  vertical-align: middle;
-}
-
-.input {
-  padding: 6px 10px;
-  font-size: 14px;
-  width: 100%;
-  box-sizing: border-box;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-}
-
-.dateRange {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.actionGroup {
-  display: flex;
-  justify-content: center;
-  gap: 8px;
-}
-
-/* 저장 = 수정 스타일 */
 .submitBtn {
-  background-color: #ececec;
-  color: #1e2a38;
-  padding: 8px 20px;
-  font-size: 12px;
-  border: none;
-  border-radius: 20px;
-  cursor: pointer;
-  white-space: nowrap;
+  background-color: #1e2a38;
+  color: white;
 }
 
 .submitBtn:hover {
-  background-color: #d9d9d9;
+  background-color: #2c3e50;
 }
 
-/* 취소 = 삭제 스타일 */
 .cancelBtn {
-  background-color: #f87171;
-  color: white;
-  padding: 8px 20px;
-  font-size: 12px;
-  border: none;
-  border-radius: 20px;
-  cursor: pointer;
-  white-space: nowrap;
+  background-color: #ececec;
+  color: #1e2a38;
 }
 
 .cancelBtn:hover {
-  background-color: #ef4444;
-}
-
-/* 수정 버튼 = 저장 버튼과 동일 */
-.editBtn {
-  background-color: #ececec;
-  color: #1e2a38;
-  padding: 8px 20px;
-  font-size: 12px;
-  border: none;
-  border-radius: 20px;
-  cursor: pointer;
-  margin-right: 6px;
-}
-
-.editBtn:hover {
   background-color: #d9d9d9;
-}
-
-/* 삭제 버튼 = 취소 버튼과 동일 */
-.deleteBtn {
-  background-color: #f87171;
-  color: white;
-  padding: 8px 20px;
-  font-size: 12px;
-  border: none;
-  border-radius: 20px;
-  cursor: pointer;
-}
-
-.deleteBtn:hover {
-  background-color: #ef4444;
+  color: #1e2a38;
 }
 
 .iconBtn {
   font-size: 14px;
 }
 
-/* 안내박스 */
-.alertBox {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  background-color: #fff8e1;
-  border: 1px solid #ffecb3;
-  border-radius: 8px;
-  padding: 14px 20px;
-  font-size: 14px;
-  color: #5c4300;
-  box-shadow: 0 2px 4px rgba(255, 212, 117, 0.2);
-  margin-top : 10px;
-  margin-bottom : 25px;
+/* 에러 메세지 */
+.errorText {
+  margin-top: 6px;
+  font-size: 12px;
+  color: #e53935;
 }
 
-.alertIcon {
-  font-size: 18px;
-  margin-top: 2px;
-  color: #f9a825;
-}
-
-.alertText {
-  line-height: 1.5;
+/* 버튼 위 얇은 구분선 (--- 느낌) */
+.buttonDivider {
+  margin-top: 8px;
+  margin-bottom: 16px;
+  border-top: 1px dashed #ddd;
 }

--- a/src/expo-admin/components/ticketTable/TicketTable.jsx
+++ b/src/expo-admin/components/ticketTable/TicketTable.jsx
@@ -1,0 +1,597 @@
+// TicketTable.jsx
+import React, { useMemo, useRef, useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import styles from './TicketTable.module.css';
+import { getMyExpoInfo } from '../../../api/service/expo-admin/setting/ExpoInfoService'; // 경로 확인
+
+const fieldLabelMap = {
+  name: '티켓 이름',
+  type: '타입',
+  description: '설명',
+  price: '가격(원)',
+  totalQuantity: '수량',
+  saleStartDate: '판매 시작일',
+  saleEndDate: '판매 종료일',
+  useStartDate: '사용 시작일',
+  useEndDate: '사용 종료일',
+};
+
+// 왼쪽: 기본 정보(설명까지) / 오른쪽: 가격, 수량, 기간들
+const ticketFieldsLeft = ['name', 'type', 'description'];
+const ticketFieldsRightTop = ['price', 'totalQuantity'];
+const rightFieldIsNumber = (key) => key === 'price' || key === 'totalQuantity';
+
+function TicketTable({ data = [], onUpdate, onDelete }) {
+  const { expoId } = useParams();
+
+  const [expandedId, setExpandedId] = useState(null);
+  const [editForm, setEditForm] = useState(null);
+  const [isEditing, setIsEditing] = useState(false);
+
+  // ===== TicketSettingForm 과 동일: 에러/포커스 =====
+  const [errors, setErrors] = useState({});
+  const refs = {
+    name: useRef(null),
+    type: useRef(null),
+    description: useRef(null),
+    price: useRef(null),
+    totalQuantity: useRef(null),
+    saleStartDate: useRef(null),
+    saleEndDate: useRef(null),
+    useStartDate: useRef(null),
+    useEndDate: useRef(null),
+  };
+
+  // ===== TicketSettingForm 과 동일: 제약 로드 (게시/행사 기간) =====
+  const [expoLoaded, setExpoLoaded] = useState(false);
+  const [displayStartDate, setDisplayStartDate] = useState('');
+  const [displayEndDate, setDisplayEndDate] = useState('');
+  const [expoStartDate, setExpoStartDate] = useState('');
+  const [expoEndDate, setExpoEndDate] = useState('');
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      if (!expoId) {
+        setExpoLoaded(true);
+        return;
+      }
+      try {
+        const expo = await getMyExpoInfo(expoId);
+        if (!mounted) return;
+        setDisplayStartDate(expo?.displayStartDate?.split('T')[0] || '');
+        setDisplayEndDate(expo?.displayEndDate?.split('T')[0] || '');
+        setExpoStartDate(expo?.startDate?.split('T')[0] || '');
+        setExpoEndDate(expo?.endDate?.split('T')[0] || '');
+        setExpoLoaded(true);
+      } catch (e) {
+        setExpoLoaded(true); // 실패해도 편집 가능
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [expoId]);
+
+  const handleRowClick = (row) => {
+    if (expandedId === row.ticketId) {
+      setExpandedId(null);
+      setEditForm(null);
+      setIsEditing(false);
+      setErrors({});
+    } else {
+      setExpandedId(row.ticketId);
+      setEditForm({ ...row });
+      setIsEditing(false);
+      setErrors({});
+    }
+  };
+
+  // ===== TicketSettingForm 과 동일: 날짜 클램프 =====
+  const clampDate = (v, min, max) => {
+    if (!v) return v;
+    let nv = v;
+    if (min && nv < min) nv = min;
+    if (max && nv > max) nv = max;
+    return nv;
+  };
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+
+    setEditForm((prev) => {
+      let next = { ...prev, [name]: value };
+
+      // 판매 시작일: 게시기간 내 클램프 + 종속 필드 보정
+      if (name === 'saleStartDate') {
+        const clamped = expoLoaded
+          ? clampDate(value, displayStartDate || undefined, displayEndDate || undefined)
+          : value;
+        next.saleStartDate = clamped;
+
+        if (next.saleEndDate && next.saleEndDate < clamped) next.saleEndDate = clamped;
+        if (expoLoaded && displayEndDate && next.saleEndDate && next.saleEndDate > displayEndDate) {
+          next.saleEndDate = displayEndDate;
+        }
+        if (next.useStartDate && next.useStartDate < clamped) next.useStartDate = clamped;
+        if (next.useEndDate && next.useEndDate < (next.useStartDate || clamped)) {
+          next.useEndDate = next.useStartDate || clamped;
+        }
+      }
+
+      // 판매 종료일: [판매 시작일, 게시 종료일]
+      if (name === 'saleEndDate') {
+        const minStart = next.saleStartDate || prev.saleStartDate;
+        next.saleEndDate = expoLoaded
+          ? clampDate(value, minStart || displayStartDate || undefined, displayEndDate || undefined)
+          : value;
+      }
+
+      // 사용 시작일: [max(행사 시작일, 판매 시작일), 행사 종료일]
+      if (name === 'useStartDate') {
+        const minBySale = next.saleStartDate || prev.saleStartDate;
+        let min = expoStartDate || undefined;
+        if (minBySale) min = min ? (minBySale > min ? minBySale : min) : minBySale;
+        const clamped = expoLoaded ? clampDate(value, min, expoEndDate || undefined) : value;
+        next.useStartDate = clamped;
+
+        if (next.useEndDate && next.useEndDate < clamped) next.useEndDate = clamped;
+        if (expoLoaded && expoEndDate && next.useEndDate && next.useEndDate > expoEndDate) {
+          next.useEndDate = expoEndDate;
+        }
+      }
+
+      // 사용 종료일: [사용 시작일, 행사 종료일]
+      if (name === 'useEndDate') {
+        const minUseStart = next.useStartDate || prev.useStartDate || expoStartDate || undefined;
+        next.useEndDate = expoLoaded
+          ? clampDate(value, minUseStart, expoEndDate || undefined)
+          : value;
+      }
+
+      // 안전장치
+      if (name === 'saleStartDate' && next.saleEndDate && next.saleEndDate < next.saleStartDate) {
+        next.saleEndDate = next.saleStartDate;
+      }
+      if (name === 'useStartDate' && next.useEndDate && next.useEndDate < next.useStartDate) {
+        next.useEndDate = next.useStartDate;
+      }
+
+      return next;
+    });
+
+    // 수정한 필드 에러 제거
+    setErrors((prev) => ({ ...prev, [name]: '' }));
+  };
+
+  // 사용 시작일 input용 min 계산 (행사 시작 vs 판매 시작 중 늦은 날짜)
+  const minUseStart = useMemo(() => {
+    if (!editForm) return undefined;
+    const cands = [];
+    if (expoStartDate) cands.push(expoStartDate);
+    if (editForm.saleStartDate) cands.push(editForm.saleStartDate);
+    if (!cands.length) return undefined;
+    return cands.sort()[cands.length - 1];
+  }, [expoStartDate, editForm]);
+
+  // ===== TicketSettingForm 과 동일: 유효성 검사 =====
+  const isBlank = (s) => !s || String(s).trim() === '';
+
+  const runValidation = () => {
+    const e = {};
+    const f = editForm || {};
+
+    // 왼쪽: 이름 → 타입 → 설명
+    if (isBlank(f.name)) e.name = '티켓 이름은 필수입니다.';
+    else if (f.name.length > 100) e.name = '티켓 이름은 100자 이하여야 합니다.';
+
+    if (isBlank(e.name)) {
+      if (isBlank(f.type)) e.type = '티켓 타입은 필수입니다.';
+    }
+
+    if (isBlank(e.name) && isBlank(e.type)) {
+      if (isBlank(f.description)) e.description = '티켓 설명은 필수입니다.';
+    }
+
+    // 오른쪽: 가격 → 수량 → 판매기간 → 사용기간
+    if (isBlank(e.name) && isBlank(e.type) && isBlank(e.description)) {
+      if (f.price === '' || f.price === null || typeof f.price === 'undefined')
+        e.price = '티켓 가격은 필수입니다.';
+      else if (isNaN(Number(f.price))) e.price = '가격은 숫자여야 합니다.';
+      else if (Number(f.price) < 0) e.price = '가격은 0원 이상이어야 합니다.';
+    }
+
+    if (isBlank(e.name) && isBlank(e.type) && isBlank(e.description) && isBlank(e.price)) {
+      if (f.totalQuantity === '' || f.totalQuantity === null || typeof f.totalQuantity === 'undefined')
+        e.totalQuantity = '티켓 수량은 필수입니다.';
+      else if (isNaN(Number(f.totalQuantity))) e.totalQuantity = '티켓 수량은 숫자여야 합니다.';
+      else if (Number(f.totalQuantity) < 1) e.totalQuantity = '티켓 수량은 1장 이상이어야 합니다.';
+    }
+
+    if (
+      isBlank(e.name) &&
+      isBlank(e.type) &&
+      isBlank(e.description) &&
+      isBlank(e.price) &&
+      isBlank(e.totalQuantity)
+    ) {
+      if (isBlank(f.saleStartDate)) e.saleStartDate = '판매 시작일은 필수입니다.';
+      if (isBlank(f.saleEndDate)) e.saleEndDate = '판매 종료일은 필수입니다.';
+
+      if (isBlank(e.saleStartDate) && isBlank(e.saleEndDate)) {
+        if (f.saleEndDate < f.saleStartDate)
+          e.saleEndDate = '판매 종료일은 시작일과 같거나 이후여야 합니다.';
+        if (displayStartDate && f.saleStartDate && f.saleStartDate < displayStartDate)
+          e.saleStartDate = '판매 시작일은 게시 시작일과 같거나 이후여야 합니다.';
+        if (displayEndDate && f.saleStartDate && f.saleStartDate > displayEndDate)
+          e.saleStartDate = '판매 시작일은 게시 종료일과 같거나 이전이어야 합니다.';
+        if (displayEndDate && f.saleEndDate && f.saleEndDate > displayEndDate)
+          e.saleEndDate = '판매 종료일은 게시 종료일과 같거나 이전이어야 합니다.';
+      }
+    }
+
+    if (
+      isBlank(e.name) &&
+      isBlank(e.type) &&
+      isBlank(e.description) &&
+      isBlank(e.price) &&
+      isBlank(e.totalQuantity) &&
+      isBlank(e.saleStartDate) &&
+      isBlank(e.saleEndDate)
+    ) {
+      if (isBlank(f.useStartDate)) e.useStartDate = '사용 시작일은 필수입니다.';
+      if (isBlank(f.useEndDate)) e.useEndDate = '사용 종료일은 필수입니다.';
+
+      if (isBlank(e.useStartDate) && isBlank(e.useEndDate)) {
+        if (f.useEndDate < f.useStartDate)
+          e.useEndDate = '사용 종료일은 시작일과 같거나 이후여야 합니다.';
+        if (f.useStartDate < f.saleStartDate)
+          e.useStartDate = '사용 시작일은 판매 시작일과 같거나 이후여야 합니다.';
+        if (expoStartDate && f.useStartDate && f.useStartDate < expoStartDate)
+          e.useStartDate = '사용 시작일은 행사 시작일과 같거나 이후여야 합니다.';
+        if (expoEndDate && f.useEndDate && f.useEndDate > expoEndDate)
+          e.useEndDate = '사용 종료일은 행사 종료일과 같거나 이전이어야 합니다.';
+      }
+    }
+
+    return e;
+  };
+
+  const focusFirstError = (e) => {
+    const order = [
+      'name',
+      'type',
+      'description',
+      'price',
+      'totalQuantity',
+      'saleStartDate',
+      'saleEndDate',
+      'useStartDate',
+      'useEndDate',
+    ];
+    for (const key of order) {
+      if (e[key]) {
+        refs[key]?.current?.focus?.();
+        break;
+      }
+    }
+  };
+
+  const handleEditStart = () => {
+    setIsEditing(true);
+    setErrors({});
+  };
+
+  const handleSave = () => {
+    const e = runValidation();
+    setErrors(e);
+    if (Object.values(e).some(Boolean)) {
+      focusFirstError(e);
+      return;
+    }
+    const payload = {
+      ...editForm,
+      price: editForm.price === '' ? '' : Number(editForm.price),
+      totalQuantity: editForm.totalQuantity === '' ? '' : Number(editForm.totalQuantity),
+    };
+    onUpdate(payload);
+    setIsEditing(false);
+  };
+
+  const handleDeleteClick = (e, ticketId) => {
+    e.stopPropagation();
+    onDelete(ticketId);
+    setExpandedId(null);
+    setEditForm(null);
+    setIsEditing(false);
+    setErrors({});
+  };
+
+  const handleCancel = () => {
+    const original = data.find((d) => d.ticketId === expandedId);
+    setEditForm(original ? { ...original } : null);
+    setIsEditing(false);
+    setErrors({});
+  };
+
+  const columns = [
+    { header: '티켓 이름', key: 'name' },
+    { header: '타입', key: 'type' },
+    { header: '가격(원)', key: 'price' },
+    { header: '수량', key: 'totalQuantity' },
+    { header: '판매 기간', key: 'saleRange' },
+    { header: '사용 기간', key: 'useRange' },
+  ];
+
+  return (
+    <div className={styles.tableWrapper}>
+      <table className={styles.table}>
+        <thead>
+          <tr className={styles.headerRow}>
+            {columns.map((col) => (
+              <th key={col.key} className={styles.th}>
+                {col.header}
+              </th>
+            ))}
+            <th className={styles.th}>관리</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row) => {
+            const isExpanded = expandedId === row.ticketId;
+            const saleRange = `${row.saleStartDate ?? ''} ~ ${row.saleEndDate ?? ''}`;
+            const useRange = `${row.useStartDate ?? ''} ~ ${row.useEndDate ?? ''}`;
+
+            return (
+              <React.Fragment key={row.ticketId}>
+                <tr className={styles.row} onClick={() => handleRowClick(row)}>
+                  <td className={styles.td}>{row.name}</td>
+                  <td className={styles.td}>{row.type}</td>
+                  <td className={styles.td}>{String(row.price ?? '')}</td>
+                  <td className={styles.td}>{String(row.totalQuantity ?? '')}</td>
+                  <td className={styles.td}>{saleRange}</td>
+                  <td className={styles.td}>{useRange}</td>
+                  <td className={styles.td}>
+                    <div className={styles.buttonGroupInline}>
+                      <button
+                        className={styles.deleteBtn}
+                        onClick={(e) => handleDeleteClick(e, row.ticketId)}
+                      >
+                        삭제
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+
+                {isExpanded && editForm && (
+                  <tr key={`detail-${row.ticketId}`} className={styles.detailRow}>
+                    <td colSpan={columns.length + 1}>
+                      <div className={styles.detailBox} onClick={(e) => e.stopPropagation()}>
+                        <div className={styles.detailGrid}>
+                          {/* 왼쪽: 기본 정보 */}
+                          <div className={styles.column}>
+                            {ticketFieldsLeft.map((key) => (
+                              <div key={key} className={styles.detailItem}>
+                                <div className={styles.detailLabel}>{fieldLabelMap[key]}</div>
+
+                                {!isEditing ? (
+                                  <div className={styles.valueText}>{editForm[key] ?? ''}</div>
+                                ) : (
+                                  <>
+                                    {key === 'type' ? (
+                                      <>
+                                        <select
+                                          ref={refs.type}
+                                          name="type"
+                                          value={editForm.type || ''}
+                                          onChange={handleChange}
+                                          className={styles.inputField}
+                                          aria-invalid={!!errors.type}
+                                        >
+                                          <option value="">타입 선택</option>
+                                          <option value="얼리버드">얼리버드</option>
+                                          <option value="일반">일반</option>
+                                        </select>
+                                        {errors.type && (
+                                          <p className={styles.errorText}>{errors.type}</p>
+                                        )}
+                                      </>
+                                    ) : (
+                                      <>
+                                        <input
+                                          ref={refs[key]}
+                                          type="text"
+                                          name={key}
+                                          value={editForm[key] ?? ''}
+                                          onChange={handleChange}
+                                          className={styles.inputField}
+                                          aria-invalid={!!errors[key]}
+                                          placeholder={
+                                            key === 'name'
+                                              ? '티켓 이름 입력'
+                                              : key === 'description'
+                                              ? '설명 입력'
+                                              : undefined
+                                          }
+                                        />
+                                        {errors[key] && (
+                                          <p className={styles.errorText}>{errors[key]}</p>
+                                        )}
+                                      </>
+                                    )}
+                                  </>
+                                )}
+                              </div>
+                            ))}
+                          </div>
+
+                          {/* 오른쪽: 가격/수량 + 기간 */}
+                          <div className={styles.column}>
+                            {ticketFieldsRightTop.map((key) => (
+                              <div key={key} className={styles.detailItem}>
+                                <div className={styles.detailLabel}>{fieldLabelMap[key]}</div>
+
+                                {!isEditing ? (
+                                  <div className={styles.valueText}>
+                                    {String(editForm[key] ?? '')}
+                                  </div>
+                                ) : (
+                                  <>
+                                    <input
+                                      ref={refs[key]}
+                                      type={rightFieldIsNumber(key) ? 'number' : 'text'}
+                                      name={key}
+                                      value={editForm[key] ?? ''}
+                                      onChange={handleChange}
+                                      className={styles.inputField}
+                                      min={key === 'price' ? 0 : key === 'totalQuantity' ? 1 : undefined}
+                                      aria-invalid={!!errors[key]}
+                                      placeholder={key === 'price' ? '가격 입력' : '수량 입력'}
+                                    />
+                                    {errors[key] && (
+                                      <p className={styles.errorText}>{errors[key]}</p>
+                                    )}
+                                  </>
+                                )}
+                              </div>
+                            ))}
+
+                            {/* 판매 기간 */}
+                            <div className={styles.detailItem}>
+                              <div className={styles.detailLabel}>판매 기간</div>
+
+                              {!isEditing ? (
+                                <div className={styles.valueGroup}>
+                                  <span className={styles.valueText}>
+                                    {editForm.saleStartDate || ''}
+                                  </span>
+                                  <span className={styles.tilde}>~</span>
+                                  <span className={styles.valueText}>
+                                    {editForm.saleEndDate || ''}
+                                  </span>
+                                </div>
+                              ) : (
+                                <>
+                                  <div className={styles.timeGroup}>
+                                    <input
+                                      ref={refs.saleStartDate}
+                                      type="date"
+                                      name="saleStartDate"
+                                      value={editForm.saleStartDate || ''}
+                                      onChange={handleChange}
+                                      className={styles.inputField}
+                                      min={expoLoaded && displayStartDate ? displayStartDate : undefined}
+                                      max={expoLoaded && displayEndDate ? displayEndDate : undefined}
+                                      aria-invalid={!!errors.saleStartDate}
+                                    />
+                                    <span className={styles.tilde}>~</span>
+                                    <input
+                                      ref={refs.saleEndDate}
+                                      type="date"
+                                      name="saleEndDate"
+                                      value={editForm.saleEndDate || ''}
+                                      onChange={handleChange}
+                                      className={styles.inputField}
+                                      min={
+                                        (editForm.saleStartDate ||
+                                          (expoLoaded && displayStartDate ? displayStartDate : undefined)) ||
+                                        undefined
+                                      }
+                                      max={expoLoaded && displayEndDate ? displayEndDate : undefined}
+                                      aria-invalid={!!errors.saleEndDate}
+                                    />
+                                  </div>
+                                  {(errors.saleStartDate || errors.saleEndDate) && (
+                                    <p className={styles.errorText}>
+                                      {errors.saleStartDate || errors.saleEndDate}
+                                    </p>
+                                  )}
+                                </>
+                              )}
+                            </div>
+
+                            {/* 사용 기간 */}
+                            <div className={styles.detailItem}>
+                              <div className={styles.detailLabel}>사용 기간</div>
+
+                              {!isEditing ? (
+                                <div className={styles.valueGroup}>
+                                  <span className={styles.valueText}>
+                                    {editForm.useStartDate || ''}
+                                  </span>
+                                  <span className={styles.tilde}>~</span>
+                                  <span className={styles.valueText}>
+                                    {editForm.useEndDate || ''}
+                                  </span>
+                                </div>
+                              ) : (
+                                <>
+                                  <div className={styles.timeGroup}>
+                                    <input
+                                      ref={refs.useStartDate}
+                                      type="date"
+                                      name="useStartDate"
+                                      value={editForm.useStartDate || ''}
+                                      onChange={handleChange}
+                                      className={styles.inputField}
+                                      min={expoLoaded ? minUseStart : undefined}
+                                      max={expoLoaded && expoEndDate ? expoEndDate : undefined}
+                                      aria-invalid={!!errors.useStartDate}
+                                    />
+                                    <span className={styles.tilde}>~</span>
+                                    <input
+                                      ref={refs.useEndDate}
+                                      type="date"
+                                      name="useEndDate"
+                                      value={editForm.useEndDate || ''}
+                                      onChange={handleChange}
+                                      className={styles.inputField}
+                                      min={
+                                        editForm.useStartDate ||
+                                        (expoLoaded && expoStartDate ? expoStartDate : undefined)
+                                      }
+                                      max={expoLoaded && expoEndDate ? expoEndDate : undefined}
+                                      aria-invalid={!!errors.useEndDate}
+                                    />
+                                  </div>
+                                  {(errors.useStartDate || errors.useEndDate) && (
+                                    <p className={styles.errorText}>
+                                      {errors.useStartDate || errors.useEndDate}
+                                    </p>
+                                  )}
+                                </>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+
+                        <div className={styles.buttonGroupBottom}>
+                          {!isEditing ? (
+                            <button className={styles.editBtn} onClick={handleEditStart}>
+                              수정
+                            </button>
+                          ) : (
+                            <>
+                              <button className={styles.editBtn} onClick={handleSave}>
+                                저장
+                              </button>
+                              <button className={styles.cancelBtn} onClick={handleCancel}>
+                                취소
+                              </button>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default TicketTable;

--- a/src/expo-admin/components/ticketTable/TicketTable.module.css
+++ b/src/expo-admin/components/ticketTable/TicketTable.module.css
@@ -1,0 +1,191 @@
+.tableWrapper {
+  background-color: #fff;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.headerRow {
+  background-color: #f7f9fc;
+}
+
+.th {
+  text-align: center;
+  padding: 12px 16px;
+  font-size: 14px;
+  color: #555;
+  border-bottom: 1px solid #eee;
+  white-space: nowrap;
+}
+
+.row {
+  border-bottom: 1px solid #f0f0f0;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.row:hover {
+  background-color: #f5f8ff;
+}
+
+.td {
+  padding: 8px 16px;
+  font-size: 14px;
+  color: #222;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.detailRow {
+  background-color: #fafcff;
+}
+
+.detailBox {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  font-size: 14px;
+}
+
+.detailGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px 40px;
+}
+
+.column {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.detailItem {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+}
+
+.detailLabel {
+  font-size: 13px;
+  color: #888;
+  font-weight: 500;
+}
+
+.inputField {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  color: #333;
+}
+
+.inputField:focus {
+  outline: none;
+  border-color: #666;
+  background-color: #f9f9ff;
+}
+
+.buttonGroupInline {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  margin-top: 0;
+}
+
+.buttonGroupBottom {
+  display: flex;
+  gap: 12px;
+  padding-top: 16px;        /* 선과 버튼 간격 */
+  border-top: 1px dashed #e2e2e2; /* 구분선 */
+  justify-content: flex-start; /* 버튼 왼쪽 정렬 (원하면 center/right 로 조정 가능) */
+}
+
+.editBtn {
+  background-color: #1e2a38;
+  color: white;
+  padding: 8px 20px;
+  font-size: 12px;
+  border: none;
+  border-radius: 20px;
+  cursor: pointer;
+}
+
+.editBtn:hover {
+  background-color: #2c3e50;
+}
+
+.cancelBtn {
+  background-color: #ececec;
+  color: #1e2a38;
+  padding: 8px 20px;
+  font-size: 12px;
+  border: none;
+  border-radius: 20px;
+  cursor: pointer;
+}
+
+.cancelBtn:hover {
+  background-color: #d9d9d9;
+}
+
+.deleteBtn {
+  background-color: #f87171;
+  color: white;
+  padding: 6px 20px;
+  font-size: 12px;
+  border: none;
+  border-radius: 20px;
+  cursor: pointer;
+}
+
+.deleteBtn:hover {
+  background-color: #ef4444;
+}
+
+.timeGroup {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.tilde {
+  font-size: 16px;
+  font-weight: bold;
+  color: #555;
+}
+
+.valueText {
+  font-size: 14px;
+  color: #333;
+  line-height: 1.6;
+  font-weight:500;
+}
+
+.valueGroup {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* 에러 메세지 */
+.errorText {
+  margin-top: 6px;
+  font-size: 12px;
+  color: #e53935;
+}
+
+/* 버튼 위 얇은 구분선 (--- 느낌) */
+.buttonDivider {
+  margin-top: 8px;
+  margin-bottom: 16px;
+  border-top: 1px dashed #ddd;
+}

--- a/src/expo-admin/pages/setting/Setting.jsx
+++ b/src/expo-admin/pages/setting/Setting.jsx
@@ -1,43 +1,121 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import styles from './Setting.module.css';
+
 import ExpoSettingForm from '../../components/expoSettingForm/ExpoSettingForm';
 import TicketSettingForm from '../../components/ticketSettingForm/TicketSettingForm';
+import TicketTable from '../../components/ticketTable/TicketTable';
+
+import ToastSuccess from '../../../common/components/toastSuccess/ToastSuccess';
+import ToastFail from '../../../common/components/toastFail/ToastFail';
+
+import { FaCheckCircle } from 'react-icons/fa';
+
 import { getMyExpoInfo } from '../../../api/service/expo-admin/setting/ExpoInfoService';
+import {
+  getMyExpoTickets,
+  saveMyExpoTicket,
+  updateMyExpoTicket,
+  deleteMyExpoTicket,
+} from '../../../api/service/expo-admin/setting/TicketService';
 
 function Setting() {
   const { expoId } = useParams();
+
   const [status, setStatus] = useState('');
+  const [tickets, setTickets] = useState([]);
+  const [toast, setToast] = useState(null);
+  const [openCreate, setOpenCreate] = useState(false); // 모달 오픈
+
+  const showToast = (type, message) => {
+    setToast({ type, message });
+    setTimeout(() => setToast(null), 3000);
+  };
 
   const getStatusText = (status) => {
     const statusMap = {
-      'PENDING_APPROVAL': '승인 대기',
-      'PENDING_PAYMENT': '결제 대기',
-      'PENDING_PUBLISH': '게시 대기',
-      'PUBLISHED': '게시 중',
-      'PUBLISH_ENDED': '게시 종료',
-      'CANCELLED': '취소됨',
-      'REJECTED': '거절됨',
-      'COMPLETED': '완료됨'
+      PENDING_APPROVAL: '승인 대기',
+      PENDING_PAYMENT: '결제 대기',
+      PENDING_PUBLISH: '게시 대기',
+      PUBLISHED: '게시 중',
+      PUBLISH_ENDED: '게시 종료',
+      CANCELLED: '취소됨',
+      REJECTED: '거절됨',
+      COMPLETED: '완료됨',
     };
     return statusMap[status] || status;
   };
 
   useEffect(() => {
-    const fetchExpoStatus = async () => {
-      if (!expoId) return;
+    if (!expoId) return;
+    (async () => {
       try {
-        const data = await getMyExpoInfo(expoId);
-        setStatus(data.status);
-      } catch (error) {
-        console.error('Failed to fetch expo status:', error);
+        const [expo, list] = await Promise.all([getMyExpoInfo(expoId), getMyExpoTickets(expoId)]);
+        setStatus(expo.status);
+        setTickets(Array.isArray(list) ? list : []);
+      } catch (err) {
+        console.error(err);
+        showToast('fail', '데이터 로드에 실패했어요.');
       }
-    };
-    
-    fetchExpoStatus();
+    })();
   }, [expoId]);
+
+  const refetchTickets = async () => {
+    try {
+      const list = await getMyExpoTickets(expoId);
+      setTickets(Array.isArray(list) ? list : []);
+    } catch (err) {
+      console.error(err);
+      showToast('fail', '티켓 목록을 새로고침하지 못했어요.');
+    }
+  };
+
+  const handleCreateTicket = async (form) => {
+    try {
+      const payload = {
+        ...form,
+        price: form.price === '' ? '' : Number(form.price),
+        totalQuantity: form.totalQuantity === '' ? '' : Number(form.totalQuantity),
+      };
+      await saveMyExpoTicket(expoId, payload);
+      showToast('success', '티켓이 성공적으로 등록되었습니다.');
+      await refetchTickets();
+      return true; // 성공 → TicketSettingForm이 닫음
+    } catch (err) {
+      showToast('fail', err?.message || '티켓 등록 중 오류가 발생했습니다.');
+      return false;
+    }
+  };
+
+  const handleUpdateTicket = async (ticket) => {
+    try {
+      const payload = {
+        ...ticket,
+        price: ticket.price === '' ? '' : Number(ticket.price),
+        totalQuantity: ticket.totalQuantity === '' ? '' : Number(ticket.totalQuantity),
+      };
+      await updateMyExpoTicket(expoId, ticket.ticketId, payload);
+      showToast('success', '티켓이 성공적으로 수정되었습니다.');
+      await refetchTickets();
+    } catch (err) {
+      showToast('fail', err?.message || '티켓 수정 중 오류가 발생했습니다.');
+    }
+  };
+
+  const handleDeleteTicket = async (ticketId) => {
+    try {
+      await deleteMyExpoTicket(expoId, ticketId);
+      showToast('success', '티켓이 성공적으로 삭제되었습니다.');
+      await refetchTickets();
+    } catch (err) {
+      showToast('fail', err?.message || '티켓 삭제 중 오류가 발생했습니다.');
+    }
+  };
+
   return (
     <div className={styles.settingContainer}>
+      {toast?.type === 'success' && <ToastSuccess message={toast.message} />}
+      {toast?.type === 'fail' && <ToastFail message={toast.message} />}
 
       <div className={styles.section}>
         <h3 className={styles.sectionTitle}>
@@ -46,20 +124,32 @@ function Setting() {
             {getStatusText(status)}
           </span>
         </h3>
-        <ExpoSettingForm/>
+        <ExpoSettingForm />
       </div>
 
-      {/* Divider */}
       <div className={styles.divider} />
 
       <div className={styles.ticketSection}>
-        <h4 className={styles.sectionTitle}>티켓 관리</h4>
-        <TicketSettingForm/>
+        <div className={styles.titleRow}>
+          <h4 className={styles.sectionTitle}>티켓 목록</h4>
+          <button className={styles.addBtn} onClick={() => setOpenCreate(true)}>
+            <FaCheckCircle className={styles.addIcon} /> 티켓 등록
+          </button>
+        </div>
+
+        <TicketTable
+          data={tickets}
+          onUpdate={handleUpdateTicket}
+          onDelete={handleDeleteTicket}
+        />
       </div>
 
+      <TicketSettingForm
+        open={openCreate}
+        onClose={() => setOpenCreate(false)}
+        onSubmit={handleCreateTicket}
+      />
     </div>
-
-    
   );
 }
 

--- a/src/expo-admin/pages/setting/Setting.module.css
+++ b/src/expo-admin/pages/setting/Setting.module.css
@@ -2,7 +2,7 @@
 .settingContainer {
   display: flex;
   flex-direction: column;
-  gap: 48px;
+  gap: 30px;
   padding: 32px;
   width : 100%;
 }
@@ -18,7 +18,12 @@
 }
 
 .ticketSection {
-    width : 100%;
+    width : 80%;
+    max-width : 1550px;
+}
+
+.ticketSettingFormSection{
+    width : 60%;
     max-width : 1550px;
 }
 
@@ -27,7 +32,7 @@
 .sectionTitle {
   font-size: 20px;
   font-weight: 700;
-  margin-bottom: 8px;
+  margin-bottom : 3px;
 }
 
 /* --- Divider --- */
@@ -78,4 +83,37 @@
 
 .badgeCOMPLETED {
   background-color: #337ab7; /* 완료됨 - 파랑 */
+}
+
+/* 기존 내용 유지하고 아래만 추가 */
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  margin-bottom : 20px;
+}
+
+.addBtn {
+  margin-left : 10px;
+  background-color: #ececec;
+  color: #1e2a38;
+  font-weight: 400;
+  padding: 6px 15px;
+  font-size: 12px;
+  border: none;
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.addBtn:hover {
+  background-color: #d9d9d9;
+  color: #1e2a38;
+}
+
+.addIcon {
+  font-size: 12px;
 }


### PR DESCRIPTION
### 박람회 상세 티켓 목록 스타일을 수정하였습니다.
- 목록
<img width="1283" height="402" alt="image" src="https://github.com/user-attachments/assets/dcbb1ca7-416e-4855-9ef6-ab0b89ad2cea" />
- 상세
<img width="1316" height="810" alt="image" src="https://github.com/user-attachments/assets/9af112fb-40cc-48bc-ac26-668621f3ed92" />
- 수정
<img width="1298" height="819" alt="image" src="https://github.com/user-attachments/assets/ca5a5e96-b848-4626-b4e5-734a11cf7786" />
- 등록 모달
<img width="1425" height="760" alt="image" src="https://github.com/user-attachments/assets/dddf13dc-8c86-4ee3-999b-0159cfbc1917" />
- 유효성 검사 (폼 등록은 토스트 팝업보다 바로바로 아래에 에러 메세지를 띄우는쪽이 더 적합하다고 생각했습니다.)
<img width="1318" height="843" alt="image" src="https://github.com/user-attachments/assets/89af2ab4-e649-4caf-8f59-4b022a70845b" />
<img width="1294" height="635" alt="image" src="https://github.com/user-attachments/assets/f6fd3c48-0238-4f89-8f60-62e626125d9d" />

### 박람회 게시 기간과 개최 기간에 맞추어 판매 시작 기간, 사용 시작 기간이 비활성화 되도록 설정하였습니다.