### PR TITLE
refactor : 페이지 이동 시 스크롤 맨 위로 초기화

### DIFF
--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -1,9 +1,11 @@
 import { BrowserRouter } from "react-router-dom";
 import AppRouteBody from "./AppRouteBody";
+import ScrollToTop from "../common/ScrollToTop";
 
 function AppRouter() {
   return (
     <BrowserRouter>
+      <ScrollToTop/>
       <AppRouteBody/>
     </BrowserRouter>
   );


### PR DESCRIPTION
기존에는 페이지 간 이동 시 이전 페이지의 스크롤 위치가 다음 페이지에도 그대로 유지되는 문제가 있었습니다.
이를 수정하여 페이지 이동 시 항상 스크롤이 맨 위로 초기화되도록 하였습니다.