### PR TITLE
refactor: 알림 버튼 뱃지와 sse 연결

### DIFF
--- a/src/hooks/useNotification.js
+++ b/src/hooks/useNotification.js
@@ -1,31 +1,24 @@
 import { useEffect, useState, useCallback } from 'react';
 import { createSseInstance } from '../api/service/system/sse/SseListener';
 
-/**
- * 실시간 알림을 관리하는 커스텀 훅
- * SSE 연결을 통해 실시간 알림을 받고 화면에 표시
- */
 const useRealtimeNotification = () => {
   const [currentNotification, setCurrentNotification] = useState(null);
   const [sseInstance, setSseInstance] = useState(null);
 
-  // 알림 메시지 처리
   const handleMessage = useCallback((event) => {
     try {
       console.log('SSE 알림 수신:', event.data);
       
-      // SSE 연결 확인 메시지는 무시
-      if (event.data.includes('SSE connected')) {
+      if (event.data.includes('SSE connected') || event.data.includes('keep-alive')) {
         return;
       }
 
       const notification = JSON.parse(event.data);
       
-      // 유효한 알림인지 확인
       if (notification.type && notification.message) {
         setCurrentNotification({
           ...notification,
-          id: Date.now(), // 고유 ID 추가
+          id: Date.now(),
           timestamp: new Date()
         });
       }
@@ -34,14 +27,11 @@ const useRealtimeNotification = () => {
     }
   }, []);
 
-  // SSE 연결 오류 처리
   const handleError = useCallback((error) => {
     console.error('SSE 연결 오류:', error);
   }, []);
 
-  // SSE 연결 시작
   useEffect(() => {
-    // 로그인된 사용자만 SSE 연결
     const token = localStorage.getItem('access_token');
     if (!token) {
       console.log('토큰이 없어 SSE 연결을 시작하지 않습니다.');
@@ -61,12 +51,10 @@ const useRealtimeNotification = () => {
     };
   }, [handleMessage, handleError]);
 
-  // 알림 닫기
   const closeNotification = useCallback(() => {
     setCurrentNotification(null);
   }, []);
 
-  // 알림 강제 표시 (테스트용)
   const showTestNotification = useCallback((type = 'GENERAL', message = '테스트 알림입니다') => {
     setCurrentNotification({
       type,
@@ -79,7 +67,7 @@ const useRealtimeNotification = () => {
   return {
     currentNotification,
     closeNotification,
-    showTestNotification, // 개발/테스트용
+    showTestNotification,
     isConnected: !!sseInstance
   };
 };

--- a/src/mainpage/components/notification/NotificationButton.jsx
+++ b/src/mainpage/components/notification/NotificationButton.jsx
@@ -5,13 +5,13 @@ import NotificationModal from './NotificationModal';
 import { getNotifications } from '../../../api/service/notification/notificationApi';
 import { useNotification } from '../../../context/NotificationContext';
 
-export default function NotificationButton() {
+export default function NotificationButton({notification}) {
   const [isOpen, setIsOpen] = useState(false);
   const { unreadCount, updateUnreadCount } = useNotification();
 
   useEffect(() => {
     fetchUnreadCount();
-  }, []);
+  }, [notification]);
 
   const fetchUnreadCount = async () => {
     try {

--- a/src/mainpage/layout/MainPageLayout.jsx
+++ b/src/mainpage/layout/MainPageLayout.jsx
@@ -29,7 +29,9 @@ function MainPageLayout() {
     <NotificationProvider>
       <div className={styles.layout}>
         {/* 헤더 (네비게이션 바) */}
-        <MainPageHeader />
+        <MainPageHeader
+          notification={currentNotification}
+        />
 
         {/* 메인 콘텐츠 영역 - Outlet이 자식 라우트들을 렌더링합니다. */}
         <main className={styles.mainContent}>

--- a/src/mainpage/layout/header/MainPageHeader.jsx
+++ b/src/mainpage/layout/header/MainPageHeader.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import MemberMainPageHeader from './MemberMainPageHeader'; // 이름이 변경된 컴포넌트 임포트
 import GuestMainPageHeader from './GuestMainPageHeader';
 
-const MainPageHeader = () => {
+const MainPageHeader = ({notification}) => {
   // 로그인 상태를 관리하는 useState 훅을 사용합니다. 임시로 boolean값줘서 로그인 상태 바꾸기
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
@@ -19,7 +19,9 @@ const MainPageHeader = () => {
   return (
     <>
       {isLoggedIn ? (
-        <MemberMainPageHeader onLogout={handleLogout} /> // 이름이 변경된 컴포넌트 사용
+        <MemberMainPageHeader
+        onLogout={handleLogout}
+        notification = {notification} /> // 이름이 변경된 컴포넌트 사용
       ) : (
         <GuestMainPageHeader onLogin={handleLogin} />
       )}

--- a/src/mainpage/layout/header/MemberMainPageHeader.jsx
+++ b/src/mainpage/layout/header/MemberMainPageHeader.jsx
@@ -3,34 +3,11 @@ import { IoNotifications } from 'react-icons/io5';
 import { useNavigate } from 'react-router-dom'; // useNavigate 임포트
 import styles from './MemberMainPageHeader.module.css';
 import NotificationButton from '../../components/notification/NotificationButton';
-import { createSseInstance } from '../../../api/service/system/sse/SseListener'
 import { logout } from '../../../api/service/auth/AuthService';
-import { useNotification } from '../../../context/NotificationContext';
 
-const MemberMainPageHeader = () => {
+const MemberMainPageHeader = ({notification}) => {
   const [activeMenu, setActiveMenu] = useState('박람회 목록');
   const navigate = useNavigate(); // useNavigate 훅 사용
-  const { incrementUnreadCount } = useNotification();
-
-  useEffect(() => {
-    const sse = createSseInstance(
-      (event) => {
-        console.log('📩 SSE 메시지:', event.data);
-        // 새로운 알림이 왔을 때 읽지 않은 개수 증가
-        incrementUnreadCount();
-        
-        // 선택적으로 토스트 알림 등 추가 UI 표시 가능
-        // showToast(event.data);
-      },
-      (error) => {
-        console.error('❌ SSE 에러:', error);
-      }
-    );
-
-    return () => {
-      sse.close(); // 컴포넌트 언마운트 시 연결 해제
-    };
-  }, []);
 
   const menuItems = [
     { name: '박람회 목록', path: '/expo-list' },
@@ -96,7 +73,7 @@ const MemberMainPageHeader = () => {
 
       {/* Right Section */}
       <div className={styles.rightSection}>
-        <NotificationButton />
+        <NotificationButton notification = {notification}/>
 
         <button className={styles.logoutBtn} onClick={handleLogoutClick}>로그아웃</button>
         <button className={styles.mypageBtn} onClick={handleMypageClick}>마이페이지</button>


### PR DESCRIPTION
### 구현 기능
* 클라이언트의 sse 타임아웃을 2분으로 조정
* 서버의 sse 타임아웃을 30분으로 조정, keep-alive 핑 추가 -> 응답 없을경우 삭제되도록
* 메인페이지의 알림 뱃지 숫자를 sse와 연동
* 중복된 sse 인스턴스 호출 제거