### PR TITLE
refactor: 메인 화면에 서브 배너 렌더링 갯수 고정

### DIFF
--- a/src/mainpage/components/banners/SubBanners.jsx
+++ b/src/mainpage/components/banners/SubBanners.jsx
@@ -6,7 +6,7 @@ import styles from './SubBanners.module.css';
 export default function SubBanners({ banners }) {
   return (
     <div className={styles.grid}>
-      {banners.map((banner, idx) => (
+      {banners.slice(0, 4).map((banner, idx) => (
         <div key={idx} className={styles.item}>
           <Link key={banner.bannerId} to={banner.linkUrl} className={styles.link}>
             <img src={banner.bannerImageUrl} alt={banner.bannerId} className={styles.image} />


### PR DESCRIPTION
### 구현 기능
* 메인 화면에 서브 배너 렌더링 갯수를 4개로 고정